### PR TITLE
docs: add CHANGELOG.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,118 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Gemini CLI support with auto-detect and setup
+- Robustness improvements for hook reliability
+
+### Fixed
+- Python 3.9 compatibility for shlex command parsing
+- Matcher events and auto-detect edge cases
+
+## [0.9.0] - 2026-03-23
+
+### Added
+- IDE identity declaration configuration
+
+### Fixed
+- Resolve absolute path for `otel-hook` in setup.sh
+
+## [0.8.0] - 2026-03-22
+
+### Added
+- Claude Code and OpenCode hooks plugin support
+- `--reinstall` flag for setup.sh
+
+### Fixed
+- Deduplicate span processor registration in file and console exporters
+
+## [0.7.0] - 2026-03-19
+
+### Added
+- GenAI semantic conventions (`gen_ai.client.*` namespace, v1.37+)
+- Prefer global `otel-hook` command by default
+
+### Changed
+- README trimmed and reorganized around GenAI conventions
+
+## [0.6.0] - 2026-03-16
+
+### Added
+- GitHub-friendly README badges (release, CI, OpenTelemetry)
+- CLI-style runner label normalization for broader IDE coverage
+
+## [0.5.0] - 2026-03-16
+
+### Added
+- Claude Code and Antigravity hook compatibility
+- `otel-hook` CLI command entry point
+- GenAI v1.37 attribute support
+- Release README version updater and merged branch cleanup
+- Antigravity workflow example
+
+### Changed
+- Default to local script; add `OTEL_HOOK_USE_GLOBAL` opt-in for global command
+- Recommend pipx for installation; document pip PATH and PEP 668 pitfalls
+
+### Fixed
+- Use writable hook home directory when installed as a package
+- Install example JSON templates in wheels
+- Python 3.9 compatibility (replace 3.10+ union type syntax)
+
+## [0.4.0] - 2026-03-03
+
+### Added
+- Local-files-only export mode (skip OTLP when no endpoint configured)
+- Jaeger + local file export backend examples
+- Automated semantic release from conventional commits
+- Weekly agentic code improvement workflow
+
+### Changed
+- README improved for Reddit and AI discoverability
+
+## [0.3.0] - 2026-02-26
+
+### Added
+- `_FileSpanExporter` OTel-native file exporter (replaces manual file writes)
+- Local span persistence as JSONL for agent analysis
+- Local trace saving flag in hook response (opt-in)
+- Expanded `otel_config.example.json` with all env vars by category
+
+### Changed
+- Renamed local trace saving semantics to "local spans"
+
+### Fixed
+- Upgrade pip in CI workflows to resolve outdated dependency
+
+## [0.2.0] - 2026-02-12
+
+### Added
+- MDM support for macOS (plist) and Windows (registry) configuration
+
+## [0.1.0] - 2026-02-12
+
+### Added
+- Initial OpenTelemetry hook implementation
+- Cursor IDE hook support with session-level trace hierarchy
+- Cross-process trace context via file-based state management
+- CI/CD workflow with Python 3.9 and 3.12 matrix
+- Semantic versioning and release workflow
+- Stale session flushing (emit `ide.session` root span for unclosed sessions)
+- Copilot contributor instructions
+
+[Unreleased]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/o11y-dev/opentelemetry-hooks/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/o11y-dev/opentelemetry-hooks/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to opentelemetry-hooks
+
+## Setup
+
+```bash
+git clone https://github.com/o11y-dev/opentelemetry-hooks.git
+cd opentelemetry-hooks
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements-dev.txt
+```
+
+## Running tests
+
+```bash
+python -m pytest tests/ -v
+```
+
+Tests run against Python 3.9 and 3.12 in CI. Make sure your changes work on both.
+
+## How the hook works
+
+```
+IDE event (JSON on stdin)
+    |
+    v
+otel_hook.py
+    |-- normalizes event (camelCase / PascalCase / IDE-specific payloads)
+    |-- detects IDE from process tree + payload heuristics
+    |-- maps event to OTel span (gen_ai.client.* semantic conventions)
+    |-- manages session trace hierarchy (session -> generation -> events)
+    |-- exports via OTLP gRPC/HTTP + optional local file
+    |
+    v
+stdout: {"continue": true}   (never blocks the IDE)
+```
+
+State is managed via JSON files in the hook home directory. Lock files prevent concurrent corruption. The hook must never crash or block the IDE.
+
+## Commit convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). The release workflow auto-detects version bumps from commit prefixes:
+
+- `feat:` - new feature (minor version bump)
+- `fix:` - bug fix (patch version bump)
+- `docs:` - documentation only
+- `test:` - test changes only
+- `ci:` - CI/CD changes
+- `chore:` - maintenance
+
+Breaking changes: add `BREAKING CHANGE:` in the commit footer (major version bump).
+
+## Adding support for a new IDE
+
+1. **Add IDE detection** in `otel_hook.py`: update `_detect_ide()` with process tree or payload heuristics for the new IDE
+2. **Add event mapping** if the IDE uses non-standard event names: update `_normalize_event_name()`
+3. **Add a setup path** in `setup.sh`: add a `--<ide-name>` flag and a `setup_<ide>()` function that writes the hook config
+4. **Add an example config** in `examples/`: create `<ide>-hooks.example.json`
+5. **Add tests**: cover detection, normalization, and setup in `tests/`
+6. **Update README.md**: add the IDE to the supported events table and installation section
+
+## Adding a new event type
+
+1. Add the event name to `_normalize_event_name()` in `otel_hook.py`
+2. Handle the event in `_process_event()` with appropriate span attributes
+3. Add the event to the supported events table in `README.md`
+4. Add test coverage in `tests/test_otel_hook.py`
+
+## PR expectations
+
+- One logical change per PR
+- Tests pass on Python 3.9 and 3.12
+- Conventional commit message on the squash/merge commit
+- If you're adding IDE support, include a real example payload in the PR description
+- Open an issue first for large changes
+
+## Code style
+
+No formatter is enforced. Match the existing style: type hints where helpful, defensive error handling (the hook must never crash), and clear variable names.


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` covering all releases from v0.1.0 through v0.9.0 using [Keep a Changelog](https://keepachangelog.com) format with version comparison links
- Add `CONTRIBUTING.md` with dev setup, architecture overview (stdin JSON -> OTel spans), commit conventions, and guides for adding new IDE support and event types

## Why

The project has 9 releases and growing multi-IDE support but no centralized changelog or contributor onboarding. These docs make it easier for new contributors to understand the release history and how to extend the hook for new IDEs/events.

## Test plan

- [ ] Verify CHANGELOG version links resolve correctly on GitHub
- [ ] Verify CONTRIBUTING setup instructions work on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)