### PR TITLE
feat: publish opentelemetry-hooks to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.semver.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -122,6 +124,12 @@ jobs:
           SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.semver.outputs.version }}
         run: python -m build
 
+      - name: Verify package
+        if: steps.semver.outputs.version != ''
+        run: |
+          pip install twine
+          twine check dist/*
+
       - name: Create GitHub Release
         if: steps.semver.outputs.version != ''
         uses: softprops/action-gh-release@v2
@@ -146,3 +154,32 @@ jobs:
               gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
             fi
           done
+
+  publish:
+    needs: release
+    if: needs.release.outputs.version != ''
+    runs-on: ubuntu-latest
+    environment: CD
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v${{ needs.release.outputs.version }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install build setuptools-scm
+
+      - name: Build package
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.release.outputs.version }}
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI }}

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ rm -rf /tmp/otel-hook-source
 
 ### Prerequisites
 
-- Python 3.8+ (the setup script checks for this)
+- Python 3.11+ (the setup script checks for this)
 - An OTLP-compatible backend (Jaeger, Coralogix, Datadog, Grafana, Honeycomb, etc.)
 
 ### Other IDEs

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ rm -rf /tmp/otel-hook-source
 
 ### Prerequisites
 
-- Python 3.11+ (the setup script checks for this)
+- Python 3.12+ (the setup script checks for this)
 - An OTLP-compatible backend (Jaeger, Coralogix, Datadog, Grafana, Honeycomb, etc.)
 
 ### Other IDEs

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -357,14 +357,13 @@ _EVENT_ATTR_MAP = {
 # ---------------------------------------------------------------------------
 def _load_input() -> dict:
     if sys.stdin.isatty():
-        # Help message when run interactively from a terminal
-        print("IDE Agent OpenTelemetry Hook — pure OpenTelemetry SDK.")
-        print("")
-        print("Usage:")
-        print("    echo '{\"hook_event_name\":\"sessionStart\",\"session_id\":\"abc\"}' | python3 otel_hook.py")
-        print("")
-        print("This hook is intended to be called by an IDE (Cursor, Copilot, Claude Code) with JSON on stdin.")
-        return {}
+        print("IDE Agent OpenTelemetry Hook — pure OpenTelemetry SDK.", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("Usage:", file=sys.stderr)
+        print("    echo '{\"hook_event_name\":\"sessionStart\",\"session_id\":\"abc\"}' | python3 otel_hook.py", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("This hook is intended to be called by an IDE (Cursor, Copilot, Claude Code) with JSON on stdin.", file=sys.stderr)
+        raise SystemExit(0)
     raw = sys.stdin.read()
     if not raw.strip():
         return {}
@@ -1289,7 +1288,7 @@ def _enable_file_exporter(path: str) -> None:
 
 def _force_flush_provider(timeout_millis: int = 500) -> None:
     """Flush the SDK TracerProvider and LoggerProvider to push pending data.
-    
+
     Default timeout is short (500ms) to avoid hanging the IDE hook when the
     OTLP collector is unreachable.
     """

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -356,6 +356,15 @@ _EVENT_ATTR_MAP = {
 # I/O helpers
 # ---------------------------------------------------------------------------
 def _load_input() -> dict:
+    if sys.stdin.isatty():
+        # Help message when run interactively from a terminal
+        print("IDE Agent OpenTelemetry Hook — pure OpenTelemetry SDK.")
+        print("")
+        print("Usage:")
+        print("    echo '{\"hook_event_name\":\"sessionStart\",\"session_id\":\"abc\"}' | python3 otel_hook.py")
+        print("")
+        print("This hook is intended to be called by an IDE (Cursor, Copilot, Claude Code) with JSON on stdin.")
+        return {}
     raw = sys.stdin.read()
     if not raw.strip():
         return {}
@@ -685,6 +694,7 @@ def _flush_stale_sessions(tracer) -> None:
         return
 
     cutoff = time.time() - ttl
+    flushed_any = False
     for name in os.listdir(_SESSION_DIR):
         path = os.path.join(_SESSION_DIR, name)
         try:
@@ -700,12 +710,15 @@ def _flush_stale_sessions(tracer) -> None:
             # Flush any dangling generation (Fix for Bug 4)
             pending_gen = ctx.get("current_generation")
             if pending_gen:
-                _flush_generation(tracer, pending_gen, ctx, ide)
-            _flush_session(tracer, session_key, ctx, ide)
+                _flush_generation(tracer, pending_gen, ctx, ide, flush=False)
+            _flush_session(tracer, session_key, ctx, ide, flush=False)
             os.remove(path)
+            flushed_any = True
             _LOGGER.info("Flushed stale session %s", session_key)
         except Exception:
             continue
+    if flushed_any:
+        _force_flush_provider()
 
 
 # ---------------------------------------------------------------------------
@@ -885,6 +898,8 @@ def _load_mdm_config() -> dict:
 
     Returns a dict of key/value pairs (may be empty).  Never raises.
     """
+    if _safe_bool(os.getenv("IDE_OTEL_SKIP_MDM", "")):
+        return {}
     if sys.platform == "darwin":
         return _load_mdm_config_macos()
     if sys.platform == "win32":
@@ -1272,8 +1287,12 @@ def _enable_file_exporter(path: str) -> None:
         _FILE_EXPORTER_PATHS.add(path)
 
 
-def _force_flush_provider(timeout_millis: int = 5000) -> None:
-    """Flush the SDK TracerProvider and LoggerProvider to push pending data."""
+def _force_flush_provider(timeout_millis: int = 500) -> None:
+    """Flush the SDK TracerProvider and LoggerProvider to push pending data.
+    
+    Default timeout is short (500ms) to avoid hanging the IDE hook when the
+    OTLP collector is unreachable.
+    """
     try:
         provider = trace.get_tracer_provider()
         if hasattr(provider, "force_flush"):
@@ -1968,7 +1987,7 @@ def _make_trace_context(trace_id_hex: str, span_id_hex: str):
     if not tid or not sid:
         return None
     ctx = SpanContext(
-        trace_id=tid, span_id=sid, is_remote=False,
+        trace_id=tid, span_id=sid, is_remote=True,
         trace_flags=TraceFlags(TraceFlags.SAMPLED), trace_state=TraceState(),
     )
     return trace.set_span_in_context(NonRecordingSpan(ctx))
@@ -2167,7 +2186,7 @@ def _flatten(out: dict, prefix: str, data: dict) -> None:
 # ---------------------------------------------------------------------------
 # Flush helpers (session-level batching)
 # ---------------------------------------------------------------------------
-def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: str) -> None:
+def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: str, flush: bool = True) -> None:
     """Flush buffered generation events as a subtree under the session trace."""
     batch = sorted(
         _load_batch_events(gen_key),
@@ -2225,11 +2244,12 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
         gen_span.end(end_time=last_ts)
         _clear_batch_events(gen_key)
 
-    _force_flush_provider()
+    if flush:
+        _force_flush_provider()
     _LOGGER.info("Flushed generation %s (%d events)", gen_key, len(batch))
 
 
-def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str) -> None:
+def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush: bool = True) -> None:
     """Emit the root session span covering the full session duration."""
     start_ns = session_ctx.get("start_time_ns") or time.time_ns()
     end_ns = time.time_ns()
@@ -2251,7 +2271,8 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str) -> Non
         _log_with_span(_LOGGER, logging.INFO, session_span, "Session span: session=%s", session_key)
         session_span.end(end_time=end_ns)
 
-    _force_flush_provider()
+    if flush:
+        _force_flush_provider()
     trace_id = session_ctx.get("trace_id", "unknown")
     _LOGGER.info("Flushed session %s (trace_id=%s)", session_key, trace_id)
 
@@ -2260,6 +2281,9 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str) -> Non
 # Main
 # ---------------------------------------------------------------------------
 def main() -> int:
+    if _safe_bool(os.getenv("IDE_OTEL_LOG_EVENTS", "")):
+        # Very early log to stderr to show the hook is alive
+        sys.stderr.write(f"Hook starting (pid={os.getpid()})\n")
     _apply_config_env(_load_config())
     _configure_logging()
     _cleanup_state()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,18 @@ description = "OpenTelemetry integration for AI coding agents (Cursor IDE/CLI, G
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
+keywords = ["opentelemetry", "observability", "ai-agents", "claude", "copilot", "cursor", "gemini", "telemetry", "hooks", "tracing"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Monitoring",
+    "Topic :: System :: Logging",
+]
 dependencies = [
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-grpc",
@@ -17,6 +29,9 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://github.com/o11y-dev/opentelemetry-hooks"
+Repository = "https://github.com/o11y-dev/opentelemetry-hooks"
+Documentation = "https://github.com/o11y-dev/opentelemetry-hooks#readme"
+Issues = "https://github.com/o11y-dev/opentelemetry-hooks/issues"
 
 [project.scripts]
 otel-hook = "otel_hook:main"

--- a/setup.sh
+++ b/setup.sh
@@ -176,7 +176,12 @@ if ! command -v python3 &>/dev/null; then
   echo "❌ python3 not found. Install Python 3.12+ and re-run."
   exit 1
 fi
-echo "✅ python3 found: $(python3 --version 2>&1)"
+PYTHON3_VERSION="$(python3 --version 2>&1)"
+if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)'; then
+  echo "❌ Unsupported python3 version: $PYTHON3_VERSION. Install Python 3.12+ and re-run."
+  exit 1
+fi
+echo "✅ python3 found: $PYTHON3_VERSION"
 echo "✅ hook command: $HOOK_CMD"
 echo ""
 


### PR DESCRIPTION
## Summary

- Add `publish` job to `release.yml` using `pypa/gh-action-pypi-publish` — the missing piece for PyPI upload
- Add `twine check` before release to catch malformed packages early
- Bump minimum Python to 3.11 across `pyproject.toml`, workflows, `README.md`, and `setup.sh`
- Add `keywords`, `classifiers`, and project URLs to `pyproject.toml` for a proper PyPI listing
- Fix `is_remote=True` for cross-process trace context restore
- Add tty detection with usage help when run interactively
- Batch stale session flushes with a single `force_flush` call
- Reduce `force_flush` timeout to 500ms to avoid blocking the IDE
- Add `IDE_OTEL_SKIP_MDM` and `IDE_OTEL_LOG_EVENTS` env vars

## Prerequisites

- GitHub environment `CD` must exist (Settings → Environments)
- `PYPI` secret must be set at repo or org level with a valid PyPI API token

## Test plan

- [ ] Trigger the Release workflow manually with an explicit version
- [ ] Confirm package appears on pypi.org/project/opentelemetry-hooks