### PR TITLE
feat: add Click CLI — otel-hook setup --agent claude|cursor|copilot|gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ otel-hook setup
 # Configure a specific agent
 otel-hook setup --agent claude
 otel-hook setup --agent cursor
-otel-hook setup --agent copilot   # project-scoped (run from repo root)
+otel-hook setup --agent copilot --no-global   # project-scoped (run from repo root)
 otel-hook setup --agent gemini
 
 # Project-scoped instead of global

--- a/README.md
+++ b/README.md
@@ -102,11 +102,56 @@ Or install from a pre-built wheel from the [Releases](https://github.com/o11y-de
 pipx install opentelemetry_hooks-*.whl
 ```
 
-Once installed, `setup.sh` will automatically use the global `otel-hook` command.
+Once installed, run `otel-hook setup` to wire your agents.
 
 ## Quick Start
 
-### One-Command Setup (Cursor IDE)
+### One-Command Setup (pip/pipx install)
+
+After installing the package, configure your agents with the built-in CLI:
+
+```bash
+# Auto-detect all installed agents and configure globally
+otel-hook setup
+
+# Configure a specific agent
+otel-hook setup --agent claude
+otel-hook setup --agent cursor
+otel-hook setup --agent copilot   # project-scoped (run from repo root)
+otel-hook setup --agent gemini
+
+# Project-scoped instead of global
+otel-hook setup --agent cursor --no-global
+
+# Check registration status
+otel-hook diagnose
+
+# Remove hooks
+otel-hook uninstall --agent claude
+```
+
+Setup is idempotent — safe to re-run. Then configure your OTLP endpoint:
+
+```bash
+vim ~/.local/share/opentelemetry-hooks/otel_config.json
+```
+
+### Python API (importable)
+
+The setup functions are importable for programmatic use:
+
+```python
+from otel_hook import setup_agent, setup_claude, setup_cursor
+
+setup_claude(global_=True)   # ~/.claude/settings.json
+setup_cursor(global_=True)   # ~/.cursor/hooks.json
+setup_agent("gemini", global_=True)
+```
+
+### Source Checkout / Cursor Project Setup
+
+If you're working from a source checkout rather than a pip install, use the
+bundled `setup.sh`:
 
 ```bash
 # Project-level — hooks.json in the current repo (.cursor/hooks.json)
@@ -116,18 +161,9 @@ bash .cursor/hooks/opentelemetry-hook/setup.sh
 bash .cursor/hooks/opentelemetry-hook/setup.sh --cursor --global
 ```
 
-That's it. The script will:
-
-1. Create or **merge into** your existing `hooks.json` (safe to re-run)
-2. Create `otel_config.json` from the example template (if missing)
-3. Bootstrap the Python venv in the background (~30s on first run)
-
-Generated Cursor hook entries invoke `otel-hook` directly. The runtime now prefers parent-process discovery for the outer IDE and separately records any distinct inner engine as `gen_ai.client.agent_engine`.
-
 Then edit your endpoint config and restart Cursor:
 
 ```bash
-# Edit the OTLP endpoint + auth
 vim .cursor/hooks/opentelemetry-hook/otel_config.json
 ```
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -2478,11 +2478,30 @@ _REPO_MARKERS = (".git", ".github", ".cursor", ".claude", ".gemini", ".opencode"
 
 
 def _find_repo_root(cwd: str) -> str:
-    """Walk up from cwd to find the nearest repo/project root."""
+    """Walk up from cwd to find the nearest repo/project root.
+
+    Tries `git rev-parse --show-toplevel` first (handles worktrees where .git
+    is a file rather than a directory), then falls back to marker detection.
+    """
+    # Fast path: ask git (works for worktrees too)
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=os.path.abspath(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    # Fallback: walk up looking for well-known markers (os.path.exists handles
+    # both regular dirs and file-form .git used by worktrees/submodules)
     current = os.path.abspath(cwd)
     while True:
         for marker in _REPO_MARKERS:
-            if os.path.isdir(os.path.join(current, marker)):
+            if os.path.exists(os.path.join(current, marker)):
                 return current
         parent = os.path.dirname(current)
         if parent == current:
@@ -2499,8 +2518,8 @@ def _load_json_file(path: str) -> dict:
         with open(path) as f:
             try:
                 return json.load(f)
-            except json.JSONDecodeError:
-                return {}
+            except json.JSONDecodeError as exc:
+                raise click.ClickException(f"Invalid JSON in {path}: {exc}") from exc
     return {}
 
 
@@ -2519,6 +2538,9 @@ def _detect_available_agents() -> list:
         found.append("cursor")
     if os.path.isdir(os.path.join(home, ".claude")) or shutil.which("claude"):
         found.append("claude")
+    # Copilot: detect via gh CLI or a .github dir in the current working directory
+    if shutil.which("gh") or os.path.isdir(os.path.join(os.getcwd(), ".github")):
+        found.append("copilot")
     if os.path.isdir(os.path.join(home, ".gemini")) or shutil.which("gemini"):
         found.append("gemini")
     return found
@@ -2544,7 +2566,7 @@ def setup_cursor(global_: bool = True, cwd: str = ".") -> None:
 
     for event in _CURSOR_EVENTS:
         event_hooks = hooks.setdefault(event, [])
-        matches = [h for h in event_hooks if h.get("command") == hook_cmd]
+        matches = [h for h in event_hooks if "otel-hook" in h.get("command", "") or "otel_hook" in h.get("command", "")]
         if matches:
             changed = False
             for hook in matches:
@@ -2638,14 +2660,9 @@ def setup_copilot(cwd: str = ".") -> None:
     hooks = doc.setdefault("hooks", {})
     added, updated, skipped = [], [], []
 
-    legacy_cmds = [
-        f"env IDE_OTEL_IDE_NAME=copilot {hook_cmd}",
-        f"env IDE_OTEL_IDE_NAME=GitHub Copilot {hook_cmd}",
-    ]
-
     for event in _COPILOT_EVENTS:
         event_hooks = hooks.setdefault(event, [])
-        plain = [h for h in event_hooks if h.get("type") == "command" and h.get("bash") == hook_cmd]
+        plain = [h for h in event_hooks if "otel-hook" in h.get("bash", "") or "otel_hook" in h.get("bash", "")]
         if plain:
             changed = any("timeoutSec" not in h for h in plain)
             for h in plain:
@@ -2653,7 +2670,7 @@ def setup_copilot(cwd: str = ".") -> None:
             (updated if changed else skipped).append(event)
             continue
 
-        legacy = [h for h in event_hooks if h.get("type") == "command" and h.get("bash") in legacy_cmds]
+        legacy = [h for h in event_hooks if h not in plain and ("otel-hook" in h.get("bash", "") or "otel_hook" in h.get("bash", "")) and h.get("bash") != hook_cmd]
         if legacy:
             for h in legacy:
                 h["bash"] = hook_cmd
@@ -2915,4 +2932,4 @@ def uninstall_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 
 
 if __name__ == "__main__":
-    raise SystemExit(cli(standalone_mode=False) or 0)
+    cli()

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -2494,7 +2494,8 @@ def _find_repo_root(cwd: str) -> str:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except Exception:
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        # git not installed, timed out, or environment error — non-fatal, use marker walk
         pass
     # Fallback: walk up looking for well-known markers (os.path.exists handles
     # both regular dirs and file-form .git used by worktrees/submodules)

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -26,12 +26,15 @@ import os
 import platform
 import random
 import re
+import shutil
 import subprocess
 import sys
 import time
 import urllib.parse
 from datetime import datetime, timezone
 from typing import Optional, Tuple
+
+import click
 
 # Whether to attach OS/host attributes to every span in addition to resource attributes.
 # Defaults to False to avoid duplicate data and hot-path overhead.
@@ -231,6 +234,36 @@ _CANONICAL_EVENT = {
     "BeforeAgent": "SubagentStart",
     "AfterAgent": "SubagentStop",
 }
+
+# ---------------------------------------------------------------------------
+# Setup CLI: per-agent event lists
+# ---------------------------------------------------------------------------
+_CURSOR_EVENTS = [
+    "sessionStart", "sessionEnd", "subagentStart", "subagentStop",
+    "preToolUse", "postToolUse", "postToolUseFailure",
+    "beforeShellExecution", "afterShellExecution",
+    "beforeMCPExecution", "afterMCPExecution",
+    "beforeReadFile", "afterFileEdit",
+    "beforeSubmitPrompt", "stop",
+]
+
+_CLAUDE_EVENTS = [
+    "SessionStart", "SessionEnd", "SubagentStart", "SubagentStop",
+    "PreToolUse", "PostToolUse", "PostToolUseFailure",
+    "UserPromptSubmit", "Stop",
+]
+_CLAUDE_MATCHER_EVENTS = {"PreToolUse", "PostToolUse", "PostToolUseFailure"}
+
+_COPILOT_EVENTS = [
+    "sessionStart", "sessionEnd", "userPromptSubmitted",
+    "preToolUse", "postToolUse", "errorOccurred",
+]
+
+_GEMINI_EVENTS = [
+    "SessionStart", "SessionEnd", "BeforeAgent", "AfterAgent",
+    "BeforeModel", "AfterModel", "BeforeTool", "AfterTool",
+]
+_GEMINI_MATCHER_EVENTS = {"BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel", "BeforeTool", "AfterTool"}
 
 # Common camelCase -> snake_case aliases used by compatible hook runners.
 # Claude Code's documented hook payloads are already snake_case, but generic
@@ -2437,5 +2470,449 @@ def main() -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Setup CLI: helpers
+# ---------------------------------------------------------------------------
+
+_REPO_MARKERS = (".git", ".github", ".cursor", ".claude", ".gemini", ".opencode")
+
+
+def _find_repo_root(cwd: str) -> str:
+    """Walk up from cwd to find the nearest repo/project root."""
+    current = os.path.abspath(cwd)
+    while True:
+        for marker in _REPO_MARKERS:
+            if os.path.isdir(os.path.join(current, marker)):
+                return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return os.path.abspath(cwd)
+        current = parent
+
+
+def _resolve_hook_cmd() -> str:
+    return shutil.which("otel-hook") or "otel-hook"
+
+
+def _load_json_file(path: str) -> dict:
+    if os.path.exists(path):
+        with open(path) as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def _write_json_file(path: str, data: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _detect_available_agents() -> list:
+    """Return list of agent names whose home dirs or commands exist."""
+    found = []
+    home = os.path.expanduser("~")
+    if os.path.isdir(os.path.join(home, ".cursor")) or shutil.which("cursor"):
+        found.append("cursor")
+    if os.path.isdir(os.path.join(home, ".claude")) or shutil.which("claude"):
+        found.append("claude")
+    if os.path.isdir(os.path.join(home, ".gemini")) or shutil.which("gemini"):
+        found.append("gemini")
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Setup CLI: per-agent setup functions (public API, importable)
+# ---------------------------------------------------------------------------
+
+def setup_cursor(global_: bool = True, cwd: str = ".") -> None:
+    """Register otel-hook in Cursor's hooks.json."""
+    hook_cmd = _resolve_hook_cmd()
+    if global_:
+        hooks_path = os.path.join(os.path.expanduser("~"), ".cursor", "hooks.json")
+    else:
+        repo = _find_repo_root(cwd)
+        hooks_path = os.path.join(repo, ".cursor", "hooks.json")
+
+    doc = _load_json_file(hooks_path)
+    doc.setdefault("version", 1)
+    hooks = doc.setdefault("hooks", {})
+    added, updated, skipped = [], [], []
+
+    for event in _CURSOR_EVENTS:
+        event_hooks = hooks.setdefault(event, [])
+        matches = [h for h in event_hooks if h.get("command") == hook_cmd]
+        if matches:
+            changed = False
+            for hook in matches:
+                env = hook.get("env")
+                if isinstance(env, dict) and "IDE_OTEL_IDE_NAME" in env:
+                    env = dict(env)
+                    env.pop("IDE_OTEL_IDE_NAME", None)
+                    if env:
+                        hook["env"] = env
+                    else:
+                        hook.pop("env", None)
+                    changed = True
+            (updated if changed else skipped).append(event)
+        else:
+            event_hooks.append({"command": hook_cmd})
+            added.append(event)
+
+    _write_json_file(hooks_path, doc)
+    _log_setup_result("cursor", hooks_path, added, updated, skipped)
+
+
+def setup_claude(global_: bool = True, cwd: str = ".") -> None:
+    """Register otel-hook in Claude Code's settings.json."""
+    hook_cmd = _resolve_hook_cmd()
+    if global_:
+        settings_path = os.path.join(os.path.expanduser("~"), ".claude", "settings.json")
+    else:
+        repo = _find_repo_root(cwd)
+        settings_path = os.path.join(repo, ".claude", "settings.json")
+
+    settings = _load_json_file(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    added, updated, skipped = [], [], []
+
+    for event in _CLAUDE_EVENTS:
+        event_list = hooks.setdefault(event, [])
+        others, exact = [], []
+        for entry in event_list:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                if "otel_hook" in cmd or "otel-hook" in cmd:
+                    (exact if cmd == hook_cmd else others).append(h)
+
+        if exact:
+            changed = False
+            for hook in exact:
+                env = hook.get("env")
+                if isinstance(env, dict) and "IDE_OTEL_IDE_NAME" in env:
+                    env = dict(env)
+                    env.pop("IDE_OTEL_IDE_NAME", None)
+                    if env:
+                        hook["env"] = env
+                    else:
+                        hook.pop("env", None)
+                    changed = True
+            (updated if changed else skipped).append(event)
+            continue
+
+        if others:
+            for hook in others:
+                hook["command"] = hook_cmd
+                env = hook.get("env")
+                if isinstance(env, dict) and "IDE_OTEL_IDE_NAME" in env:
+                    env = dict(env)
+                    env.pop("IDE_OTEL_IDE_NAME", None)
+                    if env:
+                        hook["env"] = env
+                    else:
+                        hook.pop("env", None)
+            updated.append(event)
+            continue
+
+        hook_entry: dict = {"hooks": [{"type": "command", "command": hook_cmd}]}
+        if event in _CLAUDE_MATCHER_EVENTS:
+            hook_entry["matcher"] = "*"
+        event_list.append(hook_entry)
+        added.append(event)
+
+    _write_json_file(settings_path, settings)
+    _log_setup_result("claude", settings_path, added, updated, skipped)
+
+
+def setup_copilot(cwd: str = ".") -> None:
+    """Register otel-hook in GitHub Copilot's otel-hooks.json."""
+    hook_cmd = _resolve_hook_cmd()
+    repo = _find_repo_root(cwd)
+    hooks_path = os.path.join(repo, ".github", "hooks", "otel-hooks.json")
+
+    doc = _load_json_file(hooks_path)
+    doc.setdefault("version", 1)
+    hooks = doc.setdefault("hooks", {})
+    added, updated, skipped = [], [], []
+
+    legacy_cmds = [
+        f"env IDE_OTEL_IDE_NAME=copilot {hook_cmd}",
+        f"env IDE_OTEL_IDE_NAME=GitHub Copilot {hook_cmd}",
+    ]
+
+    for event in _COPILOT_EVENTS:
+        event_hooks = hooks.setdefault(event, [])
+        plain = [h for h in event_hooks if h.get("type") == "command" and h.get("bash") == hook_cmd]
+        if plain:
+            changed = any("timeoutSec" not in h for h in plain)
+            for h in plain:
+                h.setdefault("timeoutSec", 30)
+            (updated if changed else skipped).append(event)
+            continue
+
+        legacy = [h for h in event_hooks if h.get("type") == "command" and h.get("bash") in legacy_cmds]
+        if legacy:
+            for h in legacy:
+                h["bash"] = hook_cmd
+                h.setdefault("timeoutSec", 30)
+            updated.append(event)
+            continue
+
+        event_hooks.append({"type": "command", "bash": hook_cmd, "timeoutSec": 30})
+        added.append(event)
+
+    _write_json_file(hooks_path, doc)
+    _log_setup_result("copilot", hooks_path, added, updated, skipped)
+
+
+def setup_gemini(global_: bool = True, cwd: str = ".") -> None:
+    """Register otel-hook in Gemini CLI's settings.json."""
+    hook_cmd = _resolve_hook_cmd()
+    if global_:
+        settings_path = os.path.join(os.path.expanduser("~"), ".gemini", "settings.json")
+    else:
+        repo = _find_repo_root(cwd)
+        settings_path = os.path.join(repo, ".gemini", "settings.json")
+
+    settings = _load_json_file(settings_path)
+    hooks = settings.setdefault("hooks", {})
+    added, updated, skipped = [], [], []
+
+    for event in _GEMINI_EVENTS:
+        event_list = hooks.setdefault(event, [])
+        others, exact = [], []
+        for entry in event_list:
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                if "otel_hook" in cmd or "otel-hook" in cmd:
+                    (exact if cmd == hook_cmd else others).append(h)
+
+        if exact:
+            skipped.append(event)
+            continue
+
+        if others:
+            for hook in others:
+                hook["command"] = hook_cmd
+            updated.append(event)
+            continue
+
+        hook_entry: dict = {"hooks": [{"type": "command", "command": hook_cmd, "name": "otel-hook"}]}
+        if event in _GEMINI_MATCHER_EVENTS:
+            hook_entry["matcher"] = "*"
+        event_list.append(hook_entry)
+        added.append(event)
+
+    _write_json_file(settings_path, settings)
+    _log_setup_result("gemini", settings_path, added, updated, skipped)
+
+
+def setup_agent(agent: str, global_: bool = True, cwd: str = ".") -> None:
+    """Dispatcher: configure hooks for a single agent by name."""
+    if agent == "cursor":
+        setup_cursor(global_=global_, cwd=cwd)
+    elif agent == "claude":
+        setup_claude(global_=global_, cwd=cwd)
+    elif agent == "copilot":
+        setup_copilot(cwd=cwd)
+    elif agent == "gemini":
+        setup_gemini(global_=global_, cwd=cwd)
+    else:
+        raise ValueError(f"Unknown agent: {agent}")
+
+
+def _log_setup_result(agent: str, path: str, added: list, updated: list, skipped: list) -> None:
+    if added:
+        click.echo(f"  ✓ [{agent}] Added {len(added)} events ({path})")
+    if updated:
+        click.echo(f"  ✓ [{agent}] Updated {len(updated)} events")
+    if not added and not updated:
+        click.echo(f"  · [{agent}] Already up to date ({path})")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """otel-hook — OpenTelemetry hook runner and setup CLI for AI coding agents.
+
+    When called with no subcommand and piped stdin, runs as the hook runner
+    (IDE event JSON → OTel spans). Use subcommands to configure agent hooks.
+    """
+    if ctx.invoked_subcommand is None:
+        if not sys.stdin.isatty():
+            raise SystemExit(main())
+        else:
+            click.echo(ctx.get_help())
+
+
+@cli.command("setup")
+@click.option(
+    "--agent", "agents",
+    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    multiple=True,
+    help="Agent to configure. Omit to auto-detect all available agents.",
+)
+@click.option("--global/--no-global", "global_", default=True, show_default=True,
+              help="Install to global agent config (~/.claude, ~/.cursor, etc.)")
+@click.option("--cwd", default=".", show_default=True,
+              help="Project root for project-scoped installs.")
+def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
+    """Register otel-hook in one or more AI agent configs."""
+    targets = list(agents) or _detect_available_agents()
+    if not targets:
+        click.echo("No agents detected. Use --agent cursor|claude|copilot|gemini to specify one.", err=True)
+        raise SystemExit(1)
+    errors = []
+    for agent in targets:
+        try:
+            if agent == "copilot" and global_:
+                click.echo("  · [copilot] Skipping --global (Copilot hooks are repo-scoped; run without --global from your repo root)")
+                continue
+            setup_agent(agent, global_=global_, cwd=cwd)
+        except Exception as exc:
+            click.echo(f"  ✗ [{agent}] {exc}", err=True)
+            errors.append(agent)
+    if errors:
+        raise SystemExit(1)
+
+
+@cli.command("diagnose")
+@click.option(
+    "--agent", "agents",
+    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    multiple=True,
+    help="Agent to check. Omit to check all.",
+)
+@click.option("--global/--no-global", "global_", default=True)
+@click.option("--cwd", default=".")
+def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
+    """Show hook registration status for each agent."""
+    targets = list(agents) or ["cursor", "claude", "copilot", "gemini"]
+    home = os.path.expanduser("~")
+
+    paths = {
+        "cursor": os.path.join(home, ".cursor", "hooks.json") if global_ else os.path.join(_find_repo_root(cwd), ".cursor", "hooks.json"),
+        "claude": os.path.join(home, ".claude", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".claude", "settings.json"),
+        "copilot": os.path.join(_find_repo_root(cwd), ".github", "hooks", "otel-hooks.json"),
+        "gemini": os.path.join(home, ".gemini", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".gemini", "settings.json"),
+    }
+
+    for agent in targets:
+        path = paths[agent]
+        if not os.path.exists(path):
+            click.echo(f"  · [{agent}] Not found ({path})")
+            continue
+        doc = _load_json_file(path)
+        hooks = doc.get("hooks", {})
+        count = 0
+        for entries in hooks.values():
+            for entry in (entries if isinstance(entries, list) else []):
+                # cursor: {"command": "otel-hook"}
+                if "otel-hook" in entry.get("command", "") or "otel_hook" in entry.get("command", ""):
+                    count += 1
+                # copilot: {"bash": "otel-hook"}
+                if "otel-hook" in entry.get("bash", "") or "otel_hook" in entry.get("bash", ""):
+                    count += 1
+                # claude/gemini: {"hooks": [{"command": "otel-hook"}]}
+                for h in entry.get("hooks", []):
+                    if "otel-hook" in h.get("command", "") or "otel_hook" in h.get("command", ""):
+                        count += 1
+        status = f"{count} events registered" if count else "not registered"
+        click.echo(f"  {'✓' if count else '·'} [{agent}] {status} ({path})")
+
+
+@cli.command("uninstall")
+@click.option(
+    "--agent", "agents",
+    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    multiple=True,
+    required=True,
+)
+@click.option("--global/--no-global", "global_", default=True)
+@click.option("--cwd", default=".")
+def uninstall_cmd(agents: tuple, global_: bool, cwd: str) -> None:
+    """Remove otel-hook entries from agent configs."""
+    home = os.path.expanduser("~")
+    for agent in agents:
+        if agent == "cursor":
+            path = os.path.join(home, ".cursor", "hooks.json") if global_ else os.path.join(_find_repo_root(cwd), ".cursor", "hooks.json")
+            doc = _load_json_file(path)
+            hooks = doc.get("hooks", {})
+            removed = 0
+            for event in list(hooks.keys()):
+                before = len(hooks[event])
+                hooks[event] = [h for h in hooks[event] if "otel-hook" not in h.get("command", "") and "otel_hook" not in h.get("command", "")]
+                removed += before - len(hooks[event])
+                if not hooks[event]:
+                    del hooks[event]
+            if removed:
+                _write_json_file(path, doc)
+            click.echo(f"  {'✓' if removed else '·'} [cursor] Removed {removed} entries ({path})")
+
+        elif agent == "claude":
+            path = os.path.join(home, ".claude", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".claude", "settings.json")
+            settings = _load_json_file(path)
+            hooks = settings.get("hooks", {})
+            removed = 0
+            for event in list(hooks.keys()):
+                new_list = []
+                for entry in hooks[event]:
+                    surviving = [h for h in entry.get("hooks", []) if "otel-hook" not in h.get("command", "") and "otel_hook" not in h.get("command", "")]
+                    if surviving:
+                        entry["hooks"] = surviving
+                        new_list.append(entry)
+                    else:
+                        removed += 1
+                hooks[event] = new_list
+                if not hooks[event]:
+                    del hooks[event]
+            if removed:
+                _write_json_file(path, settings)
+            click.echo(f"  {'✓' if removed else '·'} [claude] Removed {removed} entries ({path})")
+
+        elif agent == "copilot":
+            path = os.path.join(_find_repo_root(cwd), ".github", "hooks", "otel-hooks.json")
+            doc = _load_json_file(path)
+            hooks = doc.get("hooks", {})
+            removed = 0
+            for event in list(hooks.keys()):
+                before = len(hooks[event])
+                hooks[event] = [h for h in hooks[event] if "otel-hook" not in h.get("bash", "") and "otel_hook" not in h.get("bash", "")]
+                removed += before - len(hooks[event])
+                if not hooks[event]:
+                    del hooks[event]
+            if removed:
+                _write_json_file(path, doc)
+            click.echo(f"  {'✓' if removed else '·'} [copilot] Removed {removed} entries ({path})")
+
+        elif agent == "gemini":
+            path = os.path.join(home, ".gemini", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".gemini", "settings.json")
+            settings = _load_json_file(path)
+            hooks = settings.get("hooks", {})
+            removed = 0
+            for event in list(hooks.keys()):
+                new_list = []
+                for entry in hooks[event]:
+                    surviving = [h for h in entry.get("hooks", []) if "otel-hook" not in h.get("command", "") and "otel_hook" not in h.get("command", "")]
+                    if surviving:
+                        entry["hooks"] = surviving
+                        new_list.append(entry)
+                    else:
+                        removed += 1
+                hooks[event] = new_list
+                if not hooks[event]:
+                    del hooks[event]
+            if removed:
+                _write_json_file(path, settings)
+            click.echo(f"  {'✓' if removed else '·'} [gemini] Removed {removed} entries ({path})")
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(cli(standalone_mode=False) or 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Topic :: System :: Logging",
 ]
 dependencies = [
+    "click>=8.0",
     "opentelemetry-sdk",
     "opentelemetry-exporter-otlp-proto-grpc",
     "opentelemetry-exporter-otlp-proto-http",
@@ -34,7 +35,7 @@ Documentation = "https://github.com/o11y-dev/opentelemetry-hooks#readme"
 Issues = "https://github.com/o11y-dev/opentelemetry-hooks/issues"
 
 [project.scripts]
-otel-hook = "otel_hook:main"
+otel-hook = "otel_hook:cli"
 
 [tool.setuptools]
 py-modules = ["otel_hook"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest>=7.0
 ruff>=0.4
+click>=8.0
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-exporter-otlp-proto-http

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,6 @@
 import json
 import os
 
-import pytest
 from click.testing import CliRunner
 
 import otel_hook
@@ -40,9 +39,7 @@ class TestHookRunnerBackwardCompat:
 
     def test_tty_shows_help(self):
         """When called with no subcommand and no piped input, help is shown."""
-        runner = CliRunner(mix_stderr=False)
-        # Pass empty input so isatty() returns False in CliRunner — we just
-        # check that the setup/diagnose/uninstall commands appear in help output.
+        runner = CliRunner()
         result = runner.invoke(cli, ["--help"])
         assert result.exit_code == 0
         assert "setup" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,310 @@
+"""Tests for the otel-hook Click CLI (setup / diagnose / uninstall subcommands)."""
+import json
+import os
+
+import pytest
+from click.testing import CliRunner
+
+import otel_hook
+from otel_hook import cli, setup_cursor, setup_claude, setup_copilot, setup_gemini
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _read(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: hook runner path
+# ---------------------------------------------------------------------------
+
+class TestHookRunnerBackwardCompat:
+    def test_piped_stdin_runs_main(self, tmp_path, monkeypatch):
+        """When called with no subcommand and piped stdin, main() is invoked."""
+        runner = CliRunner()
+        # CliRunner sets stdin to a non-tty pipe by default
+        result = runner.invoke(cli, [], input='{"hook_event_name":"Stop","session_id":"test-bc"}')
+        # main() exits 0 and prints the continue response
+        assert result.exit_code == 0
+        assert '"continue"' in result.output or result.exit_code == 0
+
+    def test_tty_shows_help(self):
+        """When called with no subcommand and no piped input, help is shown."""
+        runner = CliRunner(mix_stderr=False)
+        # Pass empty input so isatty() returns False in CliRunner — we just
+        # check that the setup/diagnose/uninstall commands appear in help output.
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "setup" in result.output
+        assert "diagnose" in result.output
+        assert "uninstall" in result.output
+
+
+# ---------------------------------------------------------------------------
+# setup_cursor
+# ---------------------------------------------------------------------------
+
+class TestSetupCursor:
+    def test_creates_new_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        hooks_path = tmp_path / ".cursor" / "hooks.json"
+        assert hooks_path.exists()
+        doc = _read(str(hooks_path))
+        assert "hooks" in doc
+        assert "sessionStart" in doc["hooks"]
+        assert doc["hooks"]["sessionStart"] == [{"command": "otel-hook"}]
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        content_before = _read(str(tmp_path / ".cursor" / "hooks.json"))
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        content_after = _read(str(tmp_path / ".cursor" / "hooks.json"))
+        assert content_before == content_after
+
+    def test_merges_existing_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        hooks_path = tmp_path / ".cursor" / "hooks.json"
+        os.makedirs(str(hooks_path.parent))
+        _write(str(hooks_path), {"version": 1, "hooks": {"sessionStart": [{"command": "some-other-hook"}]}})
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        doc = _read(str(hooks_path))
+        # Our entry is appended, existing entry is preserved
+        cmds = [h["command"] for h in doc["hooks"]["sessionStart"]]
+        assert "otel-hook" in cmds
+        assert "some-other-hook" in cmds
+
+    def test_removes_legacy_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        hooks_path = tmp_path / ".cursor" / "hooks.json"
+        os.makedirs(str(hooks_path.parent))
+        _write(str(hooks_path), {
+            "version": 1,
+            "hooks": {
+                "sessionStart": [{"command": "otel-hook", "env": {"IDE_OTEL_IDE_NAME": "cursor"}}]
+            }
+        })
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        doc = _read(str(hooks_path))
+        entry = doc["hooks"]["sessionStart"][0]
+        assert "IDE_OTEL_IDE_NAME" not in entry.get("env", {})
+
+    def test_global_uses_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        setup_cursor(global_=True)
+        hooks_path = tmp_path / ".cursor" / "hooks.json"
+        assert hooks_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# setup_claude
+# ---------------------------------------------------------------------------
+
+class TestSetupClaude:
+    def test_creates_new_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_claude(global_=False, cwd=str(tmp_path))
+        settings_path = tmp_path / ".claude" / "settings.json"
+        assert settings_path.exists()
+        doc = _read(str(settings_path))
+        assert "hooks" in doc
+        assert "SessionStart" in doc["hooks"]
+
+    def test_preserves_existing_keys(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        settings_path = tmp_path / ".claude" / "settings.json"
+        os.makedirs(str(settings_path.parent))
+        _write(str(settings_path), {"allowedTools": ["Bash"], "hooks": {}})
+        setup_claude(global_=False, cwd=str(tmp_path))
+        doc = _read(str(settings_path))
+        assert doc["allowedTools"] == ["Bash"]
+
+    def test_matcher_events_get_matcher(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_claude(global_=False, cwd=str(tmp_path))
+        doc = _read(str(tmp_path / ".claude" / "settings.json"))
+        for event in ["PreToolUse", "PostToolUse", "PostToolUseFailure"]:
+            entries = doc["hooks"][event]
+            assert any(e.get("matcher") == "*" for e in entries)
+
+    def test_non_matcher_events_no_matcher(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_claude(global_=False, cwd=str(tmp_path))
+        doc = _read(str(tmp_path / ".claude" / "settings.json"))
+        for event in ["SessionStart", "SessionEnd", "Stop"]:
+            entries = doc["hooks"][event]
+            assert all("matcher" not in e for e in entries)
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_claude(global_=False, cwd=str(tmp_path))
+        before = _read(str(tmp_path / ".claude" / "settings.json"))
+        setup_claude(global_=False, cwd=str(tmp_path))
+        after = _read(str(tmp_path / ".claude" / "settings.json"))
+        assert before == after
+
+    def test_strips_legacy_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        settings_path = tmp_path / ".claude" / "settings.json"
+        os.makedirs(str(settings_path.parent))
+        _write(str(settings_path), {
+            "hooks": {
+                "SessionStart": [{"hooks": [{"type": "command", "command": "otel-hook", "env": {"IDE_OTEL_IDE_NAME": "claude"}}]}]
+            }
+        })
+        setup_claude(global_=False, cwd=str(tmp_path))
+        doc = _read(str(settings_path))
+        for h in doc["hooks"]["SessionStart"][0]["hooks"]:
+            assert "IDE_OTEL_IDE_NAME" not in h.get("env", {})
+
+
+# ---------------------------------------------------------------------------
+# setup_copilot
+# ---------------------------------------------------------------------------
+
+class TestSetupCopilot:
+    def test_creates_new_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_copilot(cwd=str(tmp_path))
+        hooks_path = tmp_path / ".github" / "hooks" / "otel-hooks.json"
+        assert hooks_path.exists()
+        doc = _read(str(hooks_path))
+        assert "hooks" in doc
+        assert "sessionStart" in doc["hooks"]
+
+    def test_uses_bash_key(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_copilot(cwd=str(tmp_path))
+        doc = _read(str(tmp_path / ".github" / "hooks" / "otel-hooks.json"))
+        for entries in doc["hooks"].values():
+            for h in entries:
+                assert "bash" in h
+                assert h["bash"] == "otel-hook"
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_copilot(cwd=str(tmp_path))
+        before = _read(str(tmp_path / ".github" / "hooks" / "otel-hooks.json"))
+        setup_copilot(cwd=str(tmp_path))
+        after = _read(str(tmp_path / ".github" / "hooks" / "otel-hooks.json"))
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# setup_gemini
+# ---------------------------------------------------------------------------
+
+class TestSetupGemini:
+    def test_creates_new_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_gemini(global_=False, cwd=str(tmp_path))
+        settings_path = tmp_path / ".gemini" / "settings.json"
+        assert settings_path.exists()
+
+    def test_matcher_events(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_gemini(global_=False, cwd=str(tmp_path))
+        doc = _read(str(tmp_path / ".gemini" / "settings.json"))
+        for event in ["BeforeTool", "AfterTool", "BeforeModel", "AfterModel"]:
+            entries = doc["hooks"][event]
+            assert any(e.get("matcher") == "*" for e in entries)
+
+    def test_preserves_existing_settings(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        settings_path = tmp_path / ".gemini" / "settings.json"
+        os.makedirs(str(settings_path.parent))
+        _write(str(settings_path), {"theme": "dark", "hooks": {}})
+        setup_gemini(global_=False, cwd=str(tmp_path))
+        doc = _read(str(settings_path))
+        assert doc["theme"] == "dark"
+
+
+# ---------------------------------------------------------------------------
+# CLI setup command
+# ---------------------------------------------------------------------------
+
+class TestSetupCmd:
+    def test_setup_cursor_via_cli(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        assert (tmp_path / ".cursor" / "hooks.json").exists()
+
+    def test_setup_multiple_agents(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        runner = CliRunner()
+        result = runner.invoke(cli, [
+            "setup", "--agent", "cursor", "--agent", "claude",
+            "--no-global", "--cwd", str(tmp_path)
+        ])
+        assert result.exit_code == 0
+        assert (tmp_path / ".cursor" / "hooks.json").exists()
+        assert (tmp_path / ".claude" / "settings.json").exists()
+
+    def test_copilot_skipped_with_global(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup", "--agent", "copilot", "--global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Skipping" in result.output
+
+    def test_no_agents_detected_exits_1(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_detect_available_agents", lambda: [])
+        runner = CliRunner()
+        result = runner.invoke(cli, ["setup", "--cwd", str(tmp_path)])
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI diagnose command
+# ---------------------------------------------------------------------------
+
+class TestDiagnoseCmd:
+    def test_not_found(self, tmp_path, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diagnose", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Not found" in result.output
+
+    def test_registered(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diagnose", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "events registered" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI uninstall command
+# ---------------------------------------------------------------------------
+
+class TestUninstallCmd:
+    def test_uninstall_cursor(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_cursor(global_=False, cwd=str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        doc = _read(str(tmp_path / ".cursor" / "hooks.json"))
+        for entries in doc.get("hooks", {}).values():
+            for h in entries:
+                assert "otel-hook" not in h.get("command", "")
+
+    def test_uninstall_no_file_is_noop(self, tmp_path, monkeypatch):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ class TestHookRunnerBackwardCompat:
         result = runner.invoke(cli, [], input='{"hook_event_name":"Stop","session_id":"test-bc"}')
         # main() exits 0 and prints the continue response
         assert result.exit_code == 0
-        assert '"continue"' in result.output or result.exit_code == 0
+        assert '"continue"' in result.output
 
     def test_tty_shows_help(self):
         """When called with no subcommand and no piped input, help is shown."""


### PR DESCRIPTION
## Summary

- `otel-hook setup --agent claude --global` now works — fixes `reflect setup` which called `otel-hook setup` and got a silent failure because the subcommand didn't exist
- Adds `setup`, `diagnose`, and `uninstall` Click subcommands
- Public Python API: `from otel_hook import setup_agent, setup_claude, setup_cursor` for direct import instead of subprocess
- Backward compat: bare `otel-hook` with piped stdin still runs as the hook runner (IDEs unaffected)
- Auto-detects installed agents when `--agent` is omitted
- Added `click>=8.0` dependency; entry point changed from `otel_hook:main` → `otel_hook:cli`
- Updated README with new CLI usage and Python API section

## Usage

```bash
otel-hook setup                                   # auto-detect all agents
otel-hook setup --agent claude                    # claude only, global
otel-hook setup --agent cursor --no-global        # project-scoped
otel-hook diagnose                                # show status
otel-hook uninstall --agent claude                # remove entries
```

## Test plan

- [ ] 27 new tests in `tests/test_cli.py` — all passing
- [ ] No regression in existing tests
- [ ] `reflect setup` completes step 5 successfully after `pipx install opentelemetry-hooks`