### PR TITLE
feat: add .github/hooks/otel-hooks.json for Claude Code integration

### DIFF
--- a/.github/hooks/otel-hooks.json
+++ b/.github/hooks/otel-hooks.json
@@ -1,0 +1,47 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ],
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ],
+    "postToolUse": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ],
+    "errorOccurred": [
+      {
+        "type": "command",
+        "bash": "/usr/local/bin/otel-hook",
+        "timeoutSec": 30
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.github/hooks/otel-hooks.json` to wire `otel-hook` into Claude Code sessions in this repository.

The config registers `otel-hook` as the handler for all Claude Code hook events — `sessionStart`, `sessionEnd`, `userPromptSubmitted`, `preToolUse`, `postToolUse`, and `errorOccurred` — with a 30-second timeout per invocation.

This is the same hooks config already present in the `reflect` repo and documented as the recommended setup pattern in the otel-hook README.

## Changes

| File | What changed |
|------|-------------|
| `.github/hooks/otel-hooks.json` | New — Claude Code hook runner config |