### PR TITLE
feat: add OpenCode support to otel-hook setup CLI

### DIFF
--- a/otel_hook.py
+++ b/otel_hook.py
@@ -265,6 +265,10 @@ _GEMINI_EVENTS = [
 ]
 _GEMINI_MATCHER_EVENTS = {"BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel", "BeforeTool", "AfterTool"}
 
+# OpenCode plugin — source filename (in plugin/) and destination filename (in plugins/).
+_OPENCODE_PLUGIN_SOURCE_FILENAME = "opencode.ts"
+_OPENCODE_PLUGIN_FILENAME = "otel-hook.ts"
+
 # Common camelCase -> snake_case aliases used by compatible hook runners.
 # Claude Code's documented hook payloads are already snake_case, but generic
 # runners and workflow adapters that forward Claude- or Antigravity-style
@@ -2544,7 +2548,44 @@ def _detect_available_agents() -> list:
         found.append("copilot")
     if os.path.isdir(os.path.join(home, ".gemini")) or shutil.which("gemini"):
         found.append("gemini")
+    if shutil.which("opencode") or os.path.isdir(os.path.join(home, ".config", "opencode")):
+        found.append("opencode")
     return found
+
+
+def _find_opencode_plugin_source() -> Optional[str]:
+    """Return the absolute path to the bundled plugin/opencode.ts source file.
+
+    Looks next to otel_hook.py first (source checkout), then in the installed
+    package data location (pipx / pip install).
+    """
+    # Source checkout: plugin/ lives next to otel_hook.py
+    candidate = os.path.join(os.path.dirname(os.path.abspath(__file__)), "plugin", _OPENCODE_PLUGIN_SOURCE_FILENAME)
+    if os.path.isfile(candidate):
+        return candidate
+    # Installed package data: setuptools places data files under <prefix>/share/
+    # Check the venv that contains this very module (handles pipx venvs correctly),
+    # then sys.prefix, then ~/.local as a last-resort fallback.
+    import sys
+    module_file = os.path.abspath(__file__)
+    # Walk up from the module file to find a share/ sibling (handles any venv layout)
+    check = os.path.dirname(module_file)
+    for _ in range(6):  # at most 6 levels up
+        share_candidate = os.path.join(check, "share", "opentelemetry-hooks", "plugin", _OPENCODE_PLUGIN_SOURCE_FILENAME)
+        if os.path.isfile(share_candidate):
+            return share_candidate
+        parent = os.path.dirname(check)
+        if parent == check:
+            break
+        check = parent
+    # Fallbacks: sys.prefix, sys.real_prefix, ~/.local
+    for prefix in (sys.prefix, getattr(sys, "real_prefix", None), os.path.expanduser("~/.local")):
+        if not prefix:
+            continue
+        data_candidate = os.path.join(prefix, "share", "opentelemetry-hooks", "plugin", _OPENCODE_PLUGIN_SOURCE_FILENAME)
+        if os.path.isfile(data_candidate):
+            return data_candidate
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -2728,6 +2769,48 @@ def setup_gemini(global_: bool = True, cwd: str = ".") -> None:
     _log_setup_result("gemini", settings_path, added, updated, skipped)
 
 
+def setup_opencode(global_: bool = True, cwd: str = ".") -> None:
+    """Install the otel-hook TypeScript plugin into OpenCode's plugins directory.
+
+    Global install (default): ~/.config/opencode/plugins/otel-hook.ts
+    Project install:           <repo>/.opencode/plugins/otel-hook.ts
+    """
+    src = _find_opencode_plugin_source()
+    if src is None:
+        raise click.ClickException(
+            "Cannot find plugin/opencode.ts — ensure the opentelemetry-hooks package "
+            "is installed correctly (pip install opentelemetry-hooks)."
+        )
+
+    home = os.path.expanduser("~")
+    if global_:
+        plugins_dir = os.path.join(home, ".config", "opencode", "plugins")
+    else:
+        repo = _find_repo_root(cwd)
+        plugins_dir = os.path.join(repo, ".opencode", "plugins")
+
+    dest = os.path.join(plugins_dir, _OPENCODE_PLUGIN_FILENAME)
+
+    # Check if already installed and identical
+    if os.path.isfile(dest):
+        with open(src) as f:
+            src_content = f.read()
+        with open(dest) as f:
+            dest_content = f.read()
+        if src_content == dest_content:
+            _log_setup_result("opencode", dest, [], [], [_OPENCODE_PLUGIN_FILENAME])
+            return
+        # Content differs — update
+        os.makedirs(plugins_dir, exist_ok=True)
+        shutil.copy2(src, dest)
+        _log_setup_result("opencode", dest, [], [_OPENCODE_PLUGIN_FILENAME], [])
+        return
+
+    os.makedirs(plugins_dir, exist_ok=True)
+    shutil.copy2(src, dest)
+    _log_setup_result("opencode", dest, [_OPENCODE_PLUGIN_FILENAME], [], [])
+
+
 def setup_agent(agent: str, global_: bool = True, cwd: str = ".") -> None:
     """Dispatcher: configure hooks for a single agent by name."""
     if agent == "cursor":
@@ -2738,6 +2821,8 @@ def setup_agent(agent: str, global_: bool = True, cwd: str = ".") -> None:
         setup_copilot(cwd=cwd)
     elif agent == "gemini":
         setup_gemini(global_=global_, cwd=cwd)
+    elif agent == "opencode":
+        setup_opencode(global_=global_, cwd=cwd)
     else:
         raise ValueError(f"Unknown agent: {agent}")
 
@@ -2773,7 +2858,7 @@ def cli(ctx: click.Context) -> None:
 @cli.command("setup")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
     multiple=True,
     help="Agent to configure. Omit to auto-detect all available agents.",
 )
@@ -2785,7 +2870,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
     """Register otel-hook in one or more AI agent configs."""
     targets = list(agents) or _detect_available_agents()
     if not targets:
-        click.echo("No agents detected. Use --agent cursor|claude|copilot|gemini to specify one.", err=True)
+        click.echo("No agents detected. Use --agent cursor|claude|copilot|gemini|opencode to specify one.", err=True)
         raise SystemExit(1)
     errors = []
     for agent in targets:
@@ -2804,7 +2889,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @cli.command("diagnose")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
     multiple=True,
     help="Agent to check. Omit to check all.",
 )
@@ -2812,7 +2897,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @click.option("--cwd", default=".")
 def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
     """Show hook registration status for each agent."""
-    targets = list(agents) or ["cursor", "claude", "copilot", "gemini"]
+    targets = list(agents) or ["cursor", "claude", "copilot", "gemini", "opencode"]
     home = os.path.expanduser("~")
 
     paths = {
@@ -2820,10 +2905,21 @@ def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
         "claude": os.path.join(home, ".claude", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".claude", "settings.json"),
         "copilot": os.path.join(_find_repo_root(cwd), ".github", "hooks", "otel-hooks.json"),
         "gemini": os.path.join(home, ".gemini", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".gemini", "settings.json"),
+        "opencode": (
+            os.path.join(home, ".config", "opencode", "plugins", _OPENCODE_PLUGIN_FILENAME)
+            if global_ else
+            os.path.join(_find_repo_root(cwd), ".opencode", "plugins", _OPENCODE_PLUGIN_FILENAME)
+        ),
     }
 
     for agent in targets:
         path = paths[agent]
+        if agent == "opencode":
+            if os.path.isfile(path):
+                click.echo(f"  ✓ [opencode] Plugin installed ({path})")
+            else:
+                click.echo(f"  · [opencode] Not installed ({path})")
+            continue
         if not os.path.exists(path):
             click.echo(f"  · [{agent}] Not found ({path})")
             continue
@@ -2849,7 +2945,7 @@ def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @cli.command("uninstall")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
     multiple=True,
     required=True,
 )
@@ -2859,7 +2955,20 @@ def uninstall_cmd(agents: tuple, global_: bool, cwd: str) -> None:
     """Remove otel-hook entries from agent configs."""
     home = os.path.expanduser("~")
     for agent in agents:
-        if agent == "cursor":
+        if agent == "opencode":
+            path = (
+                os.path.join(home, ".config", "opencode", "plugins", _OPENCODE_PLUGIN_FILENAME)
+                if global_ else
+                os.path.join(_find_repo_root(cwd), ".opencode", "plugins", _OPENCODE_PLUGIN_FILENAME)
+            )
+            if os.path.isfile(path):
+                os.remove(path)
+                click.echo(f"  ✓ [opencode] Removed plugin ({path})")
+            else:
+                click.echo(f"  · [opencode] Not installed ({path})")
+            continue
+
+        elif agent == "cursor":
             path = os.path.join(home, ".cursor", "hooks.json") if global_ else os.path.join(_find_repo_root(cwd), ".cursor", "hooks.json")
             doc = _load_json_file(path)
             hooks = doc.get("hooks", {})

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -2798,17 +2798,17 @@ def setup_opencode(global_: bool = True, cwd: str = ".") -> None:
         with open(dest) as f:
             dest_content = f.read()
         if src_content == dest_content:
-            _log_setup_result("opencode", dest, [], [], [_OPENCODE_PLUGIN_FILENAME])
+            click.echo(f"  · [opencode] Already up to date ({dest})")
             return
         # Content differs — update
         os.makedirs(plugins_dir, exist_ok=True)
         shutil.copy2(src, dest)
-        _log_setup_result("opencode", dest, [], [_OPENCODE_PLUGIN_FILENAME], [])
+        click.echo(f"  ✓ [opencode] Updated plugin ({dest})")
         return
 
     os.makedirs(plugins_dir, exist_ok=True)
     shutil.copy2(src, dest)
-    _log_setup_result("opencode", dest, [_OPENCODE_PLUGIN_FILENAME], [], [])
+    click.echo(f"  ✓ [opencode] Installed plugin ({dest})")
 
 
 def setup_agent(agent: str, global_: bool = True, cwd: str = ".") -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ py-modules = ["otel_hook"]
 
 [tool.setuptools.data-files]
 "share/opentelemetry-hooks" = ["otel_config.example.json"]
+"share/opentelemetry-hooks/plugin" = ["plugin/opencode.ts"]
 "share/opentelemetry-hooks/examples" = [
     "examples/antigravity-workflow.example.md",
     "examples/claude-hooks.example.json",

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1529,8 +1529,93 @@ class TestModelAttributionFallback:
             span,
             "SessionEnd",
             {"session_id": "sess-abc", "duration_ms": 5000},
-            "claude",
+             "claude",
             session_ctx=session_ctx,
         )
         attrs = self._attrs(span)
         assert attrs.get("gen_ai.request.model") == "claude-3-7-sonnet-20250219"
+
+
+# ---------------------------------------------------------------------------
+# setup_opencode
+# ---------------------------------------------------------------------------
+
+class TestSetupOpencode:
+    """Tests for setup_opencode() — installs the TypeScript plugin file."""
+
+    def _plugin_source(self):
+        """Return the path to the real plugin/opencode.ts source file."""
+        return os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "plugin", otel_hook._OPENCODE_PLUGIN_SOURCE_FILENAME,
+        )
+
+    def test_global_install_creates_plugin_file(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".config" / "opencode" / "plugins"
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        otel_hook.setup_opencode(global_=True)
+        dest = config_dir / "otel-hook.ts"
+        assert dest.is_file()
+        assert dest.read_text() == open(self._plugin_source()).read()
+
+    def test_project_install_creates_plugin_in_opencode_dir(self, tmp_path, monkeypatch):
+        # Set up a fake git repo root
+        (tmp_path / ".git").mkdir()
+        plugins_dir = tmp_path / ".opencode" / "plugins"
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        otel_hook.setup_opencode(global_=False, cwd=str(tmp_path))
+        dest = plugins_dir / "otel-hook.ts"
+        assert dest.is_file()
+
+    def test_idempotent_when_content_matches(self, tmp_path, monkeypatch, capsys):
+        config_dir = tmp_path / ".config" / "opencode" / "plugins"
+        config_dir.mkdir(parents=True)
+        src = self._plugin_source()
+        dest = config_dir / "otel-hook.ts"
+        import shutil as _shutil
+        _shutil.copy2(src, dest)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: src)
+        otel_hook.setup_opencode(global_=True)
+        captured = capsys.readouterr()
+        assert "Already up to date" in captured.out
+
+    def test_updates_when_content_differs(self, tmp_path, monkeypatch, capsys):
+        config_dir = tmp_path / ".config" / "opencode" / "plugins"
+        config_dir.mkdir(parents=True)
+        dest = config_dir / "otel-hook.ts"
+        dest.write_text("// old content")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        otel_hook.setup_opencode(global_=True)
+        assert dest.read_text() == open(self._plugin_source()).read()
+        captured = capsys.readouterr()
+        assert "Updated" in captured.out
+
+    def test_raises_when_source_not_found(self, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: None)
+        import click
+        with pytest.raises(click.ClickException, match="plugin/opencode.ts"):
+            otel_hook.setup_opencode(global_=True)
+
+    def test_detect_available_agents_includes_opencode_when_config_exists(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook.shutil, "which", lambda cmd: None)
+        found = otel_hook._detect_available_agents()
+        assert "opencode" in found
+
+    def test_detect_available_agents_includes_opencode_when_binary_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        original_which = otel_hook.shutil.which
+        monkeypatch.setattr(otel_hook.shutil, "which", lambda cmd: "/usr/local/bin/opencode" if cmd == "opencode" else None)
+        found = otel_hook._detect_available_agents()
+        assert "opencode" in found
+
+    def test_setup_agent_dispatches_to_opencode(self, tmp_path, monkeypatch):
+        called = []
+        monkeypatch.setattr(otel_hook, "setup_opencode", lambda global_, cwd: called.append((global_, cwd)))
+        otel_hook.setup_agent("opencode", global_=True, cwd="/tmp")
+        assert called == [(True, "/tmp")]

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 import time
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -1557,7 +1558,7 @@ class TestSetupOpencode:
         otel_hook.setup_opencode(global_=True)
         dest = config_dir / "otel-hook.ts"
         assert dest.is_file()
-        assert dest.read_text() == open(self._plugin_source()).read()
+        assert dest.read_text() == Path(self._plugin_source()).read_text()
 
     def test_project_install_creates_plugin_in_opencode_dir(self, tmp_path, monkeypatch):
         # Set up a fake git repo root
@@ -1589,7 +1590,7 @@ class TestSetupOpencode:
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
         otel_hook.setup_opencode(global_=True)
-        assert dest.read_text() == open(self._plugin_source()).read()
+        assert dest.read_text() == Path(self._plugin_source()).read_text()
         captured = capsys.readouterr()
         assert "Updated" in captured.out
 

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1554,7 +1554,7 @@ class TestSetupOpencode:
     def test_global_install_creates_plugin_file(self, tmp_path, monkeypatch):
         config_dir = tmp_path / ".config" / "opencode" / "plugins"
         monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", self._plugin_source)
         otel_hook.setup_opencode(global_=True)
         dest = config_dir / "otel-hook.ts"
         assert dest.is_file()
@@ -1564,7 +1564,7 @@ class TestSetupOpencode:
         # Set up a fake git repo root
         (tmp_path / ".git").mkdir()
         plugins_dir = tmp_path / ".opencode" / "plugins"
-        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", self._plugin_source)
         otel_hook.setup_opencode(global_=False, cwd=str(tmp_path))
         dest = plugins_dir / "otel-hook.ts"
         assert dest.is_file()

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1609,7 +1609,6 @@ class TestSetupOpencode:
 
     def test_detect_available_agents_includes_opencode_when_binary_exists(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
-        original_which = otel_hook.shutil.which
         monkeypatch.setattr(otel_hook.shutil, "which", lambda cmd: "/usr/local/bin/opencode" if cmd == "opencode" else None)
         found = otel_hook._detect_available_agents()
         assert "opencode" in found

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1588,7 +1588,7 @@ class TestSetupOpencode:
         dest = config_dir / "otel-hook.ts"
         dest.write_text("// old content")
         monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", lambda: self._plugin_source())
+        monkeypatch.setattr(otel_hook, "_find_opencode_plugin_source", self._plugin_source)
         otel_hook.setup_opencode(global_=True)
         assert dest.read_text() == Path(self._plugin_source()).read_text()
         captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

- `otel-hook setup --agent opencode` now installs `plugin/opencode.ts` into `~/.config/opencode/plugins/otel-hook.ts` (global, default) or `.opencode/plugins/otel-hook.ts` (project-scoped with `--no-global`). Operation is idempotent — skips if content matches, updates if the bundled plugin has changed.
- OpenCode is auto-detected in `otel-hook setup` / `otel-hook diagnose` when `~/.config/opencode/` exists or the `opencode` binary is in PATH.
- `plugin/opencode.ts` is now shipped as installed package data (`share/opentelemetry-hooks/plugin/`) so it's available after `pip install` / `pipx install`.
- `otel-hook diagnose` and `otel-hook uninstall --agent opencode` are also wired.

## Changes

| File | What changed |
|------|-------------|
| `otel_hook.py` | `setup_opencode()`, `_find_opencode_plugin_source()`, `_OPENCODE_PLUGIN_SOURCE_FILENAME`/`_OPENCODE_PLUGIN_FILENAME` constants; opencode added to `_detect_available_agents()`, `setup_agent()`, and all three CLI commands |
| `pyproject.toml` | `plugin/opencode.ts` added to `[tool.setuptools.data-files]` |
| `tests/test_otel_hook.py` | 8 new tests in `TestSetupOpencode` |

## Verification

```
$ otel-hook setup
  · [cursor] Already up to date
  · [claude] Already up to date
  · [copilot] Skipping --global
  · [gemini] Already up to date
  · [opencode] Already up to date (/Users/…/.config/opencode/plugins/otel-hook.ts)

$ otel-hook diagnose
  ✓ [opencode] Plugin installed (/Users/…/.config/opencode/plugins/otel-hook.ts)
```