### PR TITLE
Add connector-based memory enrichment, lazy OTEL loading, and fast JSON path

### DIFF
--- a/enrichment_connectors.py
+++ b/enrichment_connectors.py
@@ -1,0 +1,145 @@
+"""Connector-based memory enrichment for hook event batches.
+
+This module keeps event-memory extraction isolated from otel_hook.py so
+additional enrichers can be added without growing the main hook runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+MemoryFacts = dict[str, list[str]]
+MemoryConnector = Callable[[str, dict], MemoryFacts]
+MemorySummary = dict[str, object]
+
+
+def _empty_facts() -> MemoryFacts:
+    return {"files": [], "tools": [], "entities": [], "commands": []}
+
+
+def file_connector(_event_name: str, data: dict) -> MemoryFacts:
+    facts = _empty_facts()
+    file_path = data.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        facts["files"].append(file_path.strip())
+
+    edits = data.get("edits")
+    if isinstance(edits, list):
+        for entry in edits:
+            if isinstance(entry, dict):
+                p = entry.get("file_path") or entry.get("path")
+                if isinstance(p, str) and p.strip():
+                    facts["files"].append(p.strip())
+    elif isinstance(edits, dict):
+        p = edits.get("file_path") or edits.get("path")
+        if isinstance(p, str) and p.strip():
+            facts["files"].append(p.strip())
+    return facts
+
+
+def tool_connector(_event_name: str, data: dict) -> MemoryFacts:
+    facts = _empty_facts()
+    tool_name = data.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        facts["tools"].append(tool_name.strip())
+    return facts
+
+
+def entity_connector(_event_name: str, data: dict) -> MemoryFacts:
+    facts = _empty_facts()
+    for key in ("agent_id", "agent_name", "subagent_type", "mcp_server", "mcp_tool"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            facts["entities"].append(value.strip())
+    return facts
+
+
+def command_connector(_event_name: str, data: dict) -> MemoryFacts:
+    facts = _empty_facts()
+    command = data.get("command")
+    if isinstance(command, str) and command.strip():
+        facts["commands"].append(command.strip())
+    return facts
+
+
+DEFAULT_MEMORY_CONNECTORS: tuple[MemoryConnector, ...] = (
+    file_connector,
+    tool_connector,
+    entity_connector,
+    command_connector,
+)
+
+
+def extract_event_memory_facts(
+    event_name: str,
+    data: dict,
+    connectors: tuple[MemoryConnector, ...] = DEFAULT_MEMORY_CONNECTORS,
+) -> MemoryFacts:
+    merged = _empty_facts()
+    for connector in connectors:
+        facts = connector(event_name, data)
+        for key in merged:
+            merged[key].extend(facts.get(key, []))
+    return merged
+
+
+def aggregate_generation_memory(
+    batch: list,
+    connectors: tuple[MemoryConnector, ...] = DEFAULT_MEMORY_CONNECTORS,
+) -> MemorySummary:
+    files: list[str] = []
+    tools: list[str] = []
+    entities: list[str] = []
+    commands: list[str] = []
+    seen = {
+        "files": set(),
+        "tools": set(),
+        "entities": set(),
+        "commands": set(),
+    }
+    tool_counts: dict[str, int] = {}
+
+    for entry in batch:
+        event_name = entry.get("event") or "unknown"
+        data = entry.get("data") or {}
+        facts = extract_event_memory_facts(event_name, data, connectors=connectors)
+
+        for value in facts["files"]:
+            if value not in seen["files"]:
+                seen["files"].add(value)
+                files.append(value)
+        for value in facts["tools"]:
+            tool_counts[value] = tool_counts.get(value, 0) + 1
+            if value not in seen["tools"]:
+                seen["tools"].add(value)
+                tools.append(value)
+        for value in facts["entities"]:
+            if value not in seen["entities"]:
+                seen["entities"].add(value)
+                entities.append(value)
+        for value in facts["commands"]:
+            if value not in seen["commands"]:
+                seen["commands"].add(value)
+                commands.append(value)
+
+    return {
+        "files": files,
+        "tools": tools,
+        "entities": entities,
+        "commands": commands,
+        "tool_counts": tool_counts,
+    }
+
+
+def merge_memory_summaries(target: dict, source: MemorySummary) -> dict:
+    for key in ("files", "tools", "entities", "commands"):
+        existing = target.setdefault(key, [])
+        seen = set(existing)
+        for value in source.get(key, []):
+            if value not in seen:
+                seen.add(value)
+                existing.append(value)
+    counts = target.setdefault("tool_counts", {})
+    for tool, count in source.get("tool_counts", {}).items():
+        counts[tool] = counts.get(tool, 0) + count
+    return target

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -20,6 +20,8 @@ Usage:
 import glob
 import contextlib
 import hashlib
+import importlib
+import importlib.util
 import json
 import logging
 import os
@@ -35,6 +37,11 @@ from datetime import datetime, timezone
 from typing import Optional, Tuple
 
 import click
+from enrichment_connectors import (
+    aggregate_generation_memory,
+    extract_event_memory_facts,
+    merge_memory_summaries,
+)
 
 # Whether to attach OS/host attributes to every span in addition to resource attributes.
 # Defaults to False to avoid duplicate data and hot-path overhead.
@@ -144,35 +151,89 @@ for _sp in _VENV_SP:
     if _sp not in sys.path:
         sys.path.insert(0, _sp)
 
-try:
-    from opentelemetry import trace
-    from opentelemetry.trace import (
-        NonRecordingSpan,
-        SpanContext,
-        SpanKind,
-        Status,
-        StatusCode,
-        TraceFlags,
-        TraceState,
-        use_span,
-    )
-except Exception:
-    trace = None
-    NonRecordingSpan = None
-    SpanContext = None
-    SpanKind = None
-    Status = None
-    StatusCode = None
-    TraceFlags = None
-    TraceState = None
-    use_span = None
+class _TraceShim:
+    """Small shim so tests can monkeypatch trace methods before lazy load."""
 
-try:
-    from opentelemetry.sdk.trace.export import SpanExportResult
-except ImportError:
-    class SpanExportResult:  # minimal shim for SDK-unavailable environments
-        SUCCESS = 0
-        FAILURE = 1
+    def set_tracer_provider(self, _provider) -> None:
+        if _REAL_TRACE is not None:
+            return _REAL_TRACE.set_tracer_provider(_provider)
+        return None
+
+    def get_tracer_provider(self):
+        if _REAL_TRACE is not None:
+            return _REAL_TRACE.get_tracer_provider()
+        return None
+
+    def get_tracer(self, _name: str):
+        if _REAL_TRACE is not None:
+            return _REAL_TRACE.get_tracer(_name)
+        return None
+
+    def get_current_span(self):
+        if _REAL_TRACE is not None:
+            return _REAL_TRACE.get_current_span()
+        return None
+
+    def set_span_in_context(self, _span):
+        if _REAL_TRACE is not None:
+            return _REAL_TRACE.set_span_in_context(_span)
+        return None
+
+
+# Lazy-loaded OpenTelemetry symbols (loaded only when tracing/logging is needed).
+trace = _TraceShim()
+_OTEL_MODULES_LOADED = False
+_REAL_TRACE = None
+NonRecordingSpan = None
+SpanContext = None
+SpanKind = None
+Status = None
+StatusCode = None
+TraceFlags = None
+TraceState = None
+use_span = None
+
+
+class SpanExportResult:  # minimal shim for SDK-unavailable environments
+    SUCCESS = 0
+    FAILURE = 1
+
+
+def _load_otel_modules() -> bool:
+    """Load OpenTelemetry modules lazily; return False when unavailable."""
+    global _OTEL_MODULES_LOADED
+    global _REAL_TRACE
+    global NonRecordingSpan, SpanContext, SpanKind, Status, StatusCode, TraceFlags, TraceState, use_span
+    global SpanExportResult
+    if _OTEL_MODULES_LOADED:
+        return True
+
+    otel_spec = importlib.util.find_spec("opentelemetry")
+    if otel_spec is None:
+        return False
+    sdk_spec = importlib.util.find_spec("opentelemetry.sdk.trace.export")
+    if sdk_spec is None:
+        return False
+    otel_api = importlib.import_module("opentelemetry")
+    _REAL_TRACE = otel_api.trace
+    otel_trace = importlib.import_module("opentelemetry.trace")
+    NonRecordingSpan = otel_trace.NonRecordingSpan
+    SpanContext = otel_trace.SpanContext
+    SpanKind = otel_trace.SpanKind
+    Status = otel_trace.Status
+    StatusCode = otel_trace.StatusCode
+    TraceFlags = otel_trace.TraceFlags
+    TraceState = otel_trace.TraceState
+    use_span = otel_trace.use_span
+    sdk_export = importlib.import_module("opentelemetry.sdk.trace.export")
+    SpanExportResult = sdk_export.SpanExportResult
+    _OTEL_MODULES_LOADED = True
+    return True
+
+
+_ORJSON = None
+if importlib.util.find_spec("orjson") is not None:
+    _ORJSON = importlib.import_module("orjson")
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +461,15 @@ def _load_input() -> dict:
     raw = sys.stdin.read()
     if not raw.strip():
         return {}
+    return _fast_json_loads(raw)
+
+
+def _fast_json_loads(raw: str):
+    if _ORJSON is not None:
+        try:
+            return _ORJSON.loads(raw)
+        except Exception:
+            return {}
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
@@ -1103,6 +1173,10 @@ def _init_sdk_tracer_provider(resource_attrs: dict, disable_batch: bool) -> bool
     creates a bare TracerProvider (no OTLP exporter) so the file exporter
     can be attached later without wasted network calls.
     """
+    if not _load_otel_modules():
+        _LOGGER.error("opentelemetry-sdk not importable")
+        return False
+
     try:
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
@@ -1344,7 +1418,7 @@ def _init_tracing(ide: str = "cursor") -> bool:
     global _TRACING_INITIALIZED
     if _TRACING_INITIALIZED:
         return True
-    if trace is None:
+    if not _load_otel_modules():
         _LOGGER.error("opentelemetry-sdk not installed; tracing disabled.")
         return False
 
@@ -2216,6 +2290,44 @@ def _flatten(out: dict, prefix: str, data: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Memory enrichment (generation/session summaries)
+# ---------------------------------------------------------------------------
+def _extract_event_memory_facts(event_name: str, data: dict) -> dict:
+    """Backward-compatible wrapper for connector-based enrichment."""
+    return extract_event_memory_facts(event_name, data)
+
+
+def _aggregate_generation_memory(batch: list) -> dict:
+    """Backward-compatible wrapper for connector-based enrichment."""
+    return aggregate_generation_memory(batch)
+
+
+def _apply_memory_summary_attrs(span, prefix: str, summary: dict) -> None:
+    """Attach memory summary attributes to a span."""
+    files = summary.get("files") or []
+    tools = summary.get("tools") or []
+    entities = summary.get("entities") or []
+    commands = summary.get("commands") or []
+    tool_counts = summary.get("tool_counts") or {}
+
+    span.set_attribute(f"{prefix}.files_touched_count", len(files))
+    span.set_attribute(f"{prefix}.tools_used_count", len(tools))
+    span.set_attribute(f"{prefix}.entities_count", len(entities))
+    span.set_attribute(f"{prefix}.commands_count", len(commands))
+
+    if files:
+        span.set_attribute(f"{prefix}.files_touched", files)
+    if tools:
+        span.set_attribute(f"{prefix}.tools_used", tools)
+    if entities:
+        span.set_attribute(f"{prefix}.entities", entities)
+    if commands:
+        span.set_attribute(f"{prefix}.commands", commands)
+    if tool_counts:
+        span.set_attribute(f"{prefix}.tool_counts", json.dumps(tool_counts, ensure_ascii=True, sort_keys=True))
+
+
+# ---------------------------------------------------------------------------
 # Flush helpers (session-level batching)
 # ---------------------------------------------------------------------------
 def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: str, flush: bool = True) -> None:
@@ -2246,9 +2358,11 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
          if _first_present(e["data"], ("request_model", "model", "model_name"))),
         None
     )
+    memory_summary = _aggregate_generation_memory(batch)
 
+    span_kind = SpanKind.INTERNAL if SpanKind is not None else None
     gen_span = tracer.start_span(
-        "gen_ai.client.generation", kind=SpanKind.INTERNAL,
+        "gen_ai.client.generation", kind=span_kind,
         context=parent_ctx, start_time=first_ts,
     )
     gen_ctx = trace.set_span_in_context(gen_span)
@@ -2256,6 +2370,7 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
         gen_span.set_attribute("gen_ai.client.generation_id", gen_key)
         gen_span.set_attribute("gen_ai.client.event.count", len(batch))
         _set_if_present(gen_span, "gen_ai.request.model", batch_model)
+        _apply_memory_summary_attrs(gen_span, "gen_ai.client.memory", memory_summary)
         _set_client_identity_attributes(gen_span, ide, agent_engine=(session_ctx or {}).get("agent_engine"))
         _log_with_span(_LOGGER, logging.INFO, gen_span, "Generation span: gen_key=%s events=%d", gen_key, len(batch))
 
@@ -2266,7 +2381,7 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
             next_ts = batch[idx + 1].get("timestamp_ns") if idx + 1 < len(batch) else ts + 1_000_000
 
             span = tracer.start_span(
-                f"gen_ai.client.hook.{evt}", kind=SpanKind.INTERNAL,
+                f"gen_ai.client.hook.{evt}", kind=span_kind,
                 context=gen_ctx, start_time=ts,
             )
             with _span_context(span):
@@ -2275,6 +2390,10 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
 
         gen_span.end(end_time=last_ts)
         _clear_batch_events(gen_key)
+
+    if session_ctx is not None:
+        session_memory = session_ctx.setdefault("memory", {})
+        merge_memory_summaries(session_memory, memory_summary)
 
     if flush:
         _force_flush_provider()
@@ -2291,8 +2410,9 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush:
         session_ctx.get("phantom_parent_id", "0"),
     )
 
+    span_kind = SpanKind.INTERNAL if SpanKind is not None else None
     session_span = tracer.start_span(
-        "gen_ai.client.session", kind=SpanKind.INTERNAL,
+        "gen_ai.client.session", kind=span_kind,
         context=parent_ctx, start_time=start_ns,
     )
     with _span_context(session_span):
@@ -2300,6 +2420,7 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush:
         _set_client_identity_attributes(session_span, ide, agent_engine=session_ctx.get("agent_engine"))
         session_span.set_attribute("gen_ai.client.generation_count", session_ctx.get("generation_count", 0))
         session_span.set_attribute("gen_ai.client.session.duration_ms", (end_ns - start_ns) // 1_000_000)
+        _apply_memory_summary_attrs(session_span, "gen_ai.client.memory", session_ctx.get("memory", {}))
         _log_with_span(_LOGGER, logging.INFO, session_span, "Session span: session=%s", session_key)
         session_span.end(end_time=end_ns)
 
@@ -2327,12 +2448,41 @@ def main() -> int:
     raw_event = _get_event_name(data)
     event_name = _normalize_event(raw_event)
     ide = _detect_ide(data)
+    sk = _session_key(data)
 
     if _safe_bool(os.getenv("IDE_OTEL_LOG_EVENTS", "")):
         _LOGGER.info(
             "Hook: %s (raw=%s) | ide=%s | python=%s",
             event_name, raw_event, ide, sys.executable,
         )
+
+    # Fast path for buffered batch events (no span emission yet):
+    # avoid loading OpenTelemetry SDK for events that only append to batch files.
+    if _batch_enabled():
+        session_ctx = _load_session_context(sk)
+
+        if event_name in _SESSION_START_EVENTS:
+            if sk:
+                _create_session_context(sk, data, ide)
+                _append_batch_event(f"{sk}_session", event_name, data)
+            print(_continue_response_json())
+            return 0
+
+        if event_name in _GENERATION_START_EVENTS:
+            gen_key = _generation_key_from_data(data)
+            if not gen_key and sk and session_ctx:
+                gen_key = _advance_generation(sk, session_ctx)
+            if gen_key:
+                _append_batch_event(gen_key, event_name, data)
+            print(_continue_response_json())
+            return 0
+
+        if event_name not in _GENERATION_END_EVENTS and event_name not in _SESSION_END_EVENTS:
+            gen_key = _resolve_generation_key(data, session_ctx)
+            if gen_key:
+                _append_batch_event(gen_key, event_name, data)
+                print(_continue_response_json())
+                return 0
 
     if not _init_tracing(ide):
         print(_continue_response_json())
@@ -2345,7 +2495,6 @@ def main() -> int:
     _flush_stale_sessions(tracer)
 
     try:
-        sk = _session_key(data)
         session_ctx = _load_session_context(sk)
         agent_engine = _detect_agent_engine(data)
         if sk and session_ctx and agent_engine and agent_engine != ide and session_ctx.get("agent_engine") != agent_engine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ Issues = "https://github.com/o11y-dev/opentelemetry-hooks/issues"
 otel-hook = "otel_hook:cli"
 
 [tool.setuptools]
-py-modules = ["otel_hook"]
+py-modules = ["otel_hook", "enrichment_connectors"]
 
 [tool.setuptools.data-files]
 "share/opentelemetry-hooks" = ["otel_config.example.json"]

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -13,6 +13,7 @@ import pytest
 # Import the module under test
 # ---------------------------------------------------------------------------
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import enrichment_connectors
 import otel_hook
 
 
@@ -78,6 +79,42 @@ class TestFloatOrNone:
     def test_invalid(self):
         assert otel_hook._float_or_none("xyz") is None
 
+
+class TestMemoryAggregation:
+    def test_extract_event_memory_facts(self):
+        facts = otel_hook._extract_event_memory_facts("AfterFileEdit", {
+            "file_path": "src/main.py",
+            "tool_name": "edit",
+            "agent_name": "planner",
+            "command": "pytest -q",
+        })
+        assert facts["files"] == ["src/main.py"]
+        assert facts["tools"] == ["edit"]
+        assert "planner" in facts["entities"]
+        assert facts["commands"] == ["pytest -q"]
+
+    def test_aggregate_generation_memory_dedupes_and_counts(self):
+        batch = [
+            {"event": "PreToolUse", "data": {"tool_name": "read", "file_path": "README.md"}},
+            {"event": "PostToolUse", "data": {"tool_name": "read", "file_path": "README.md"}},
+            {"event": "AfterFileEdit", "data": {"file_path": "otel_hook.py", "tool_name": "edit"}},
+        ]
+        summary = otel_hook._aggregate_generation_memory(batch)
+        assert summary["files"] == ["README.md", "otel_hook.py"]
+        assert summary["tools"] == ["read", "edit"]
+        assert summary["tool_counts"] == {"read": 2, "edit": 1}
+
+    def test_connector_aggregation_and_merge(self):
+        batch = [
+            {"event": "PreToolUse", "data": {"tool_name": "read", "file_path": "README.md"}},
+            {"event": "AfterShellExecution", "data": {"command": "pytest -q"}},
+        ]
+        summary = enrichment_connectors.aggregate_generation_memory(batch)
+        session = {"files": ["existing.md"], "tool_counts": {"read": 1}}
+        enrichment_connectors.merge_memory_summaries(session, summary)
+        assert session["files"] == ["existing.md", "README.md"]
+        assert session["commands"] == ["pytest -q"]
+        assert session["tool_counts"]["read"] == 2
 
 # ── Event normalization ───────────────────────────────────────────────────
 
@@ -1089,6 +1126,35 @@ class TestMainFlow:
         monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
         result = otel_hook.main()
         assert result == 0
+
+    def test_batch_buffered_event_skips_tracing_init(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_BATCH_ON_STOP", "true")
+        monkeypatch.setattr("sys.stdin", __import__("io").StringIO('{"hook_event_name":"preToolUse","session_id":"s1"}'))
+        monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
+        monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
+        monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
+        monkeypatch.setattr(otel_hook, "_load_session_context", lambda _sk: {"current_generation": "g1"})
+        appended = []
+        monkeypatch.setattr(otel_hook, "_append_batch_event", lambda key, evt, data: appended.append((key, evt)))
+        called = {"init": 0}
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: called.__setitem__("init", called["init"] + 1) or True)
+        captured = []
+        monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
+        result = otel_hook.main()
+        assert result == 0
+        assert appended == [("g1", "PreToolUse")]
+        assert called["init"] == 0
+
+
+class TestFastJsonLoads:
+    def test_fast_json_loads_orjson_path(self, monkeypatch):
+        class FakeOrjson:
+            @staticmethod
+            def loads(raw):
+                return {"x": 1} if raw == '{"x":1}' else {}
+
+        monkeypatch.setattr(otel_hook, "_ORJSON", FakeOrjson)
+        assert otel_hook._fast_json_loads('{"x":1}') == {"x": 1}
 
 
 # ── Atomic write ──────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Isolate event-memory extraction into a pluggable connector layer so enrichment logic doesn't bloat the main hook runtime and can be extended easily.
- Avoid importing the heavy OpenTelemetry SDK on hot paths that only append buffered batch events, and provide a lazy shim so tests can patch tracing behavior before modules are loaded.
- Speed up JSON parsing when `orjson` is available and wire memory summaries into generation/session spans for observability.

### Description
- Introduces a new module `enrichment_connectors.py` implementing connector-based memory extraction with built-in connectors (`file_connector`, `tool_connector`, `entity_connector`, `command_connector`), aggregation via `aggregate_generation_memory`, and merging via `merge_memory_summaries`.
- Integrates the connectors into `otel_hook.py` with backward-compatible wrappers ` _extract_event_memory_facts` and `_aggregate_generation_memory`, and applies memory summary attributes to generation and session spans via `_apply_memory_summary_attrs` and session merging.
- Replaces eager `opentelemetry` imports with a lazy-loading shim (`_TraceShim`, `_load_otel_modules`) and a minimal `SpanExportResult` shim so the hook can avoid importing the SDK until tracing is required.
- Adds a fast JSON loading path `_fast_json_loads` that uses `_ORJSON` when available, and uses it from `_load_input` to improve input parsing performance.
- Implements a fast-path in `main()` that, when batch mode is enabled, appends buffered events without initializing tracing to reduce overhead for common batch-only events.
- Updates `pyproject.toml` to include the new `enrichment_connectors` module in `py-modules`.
- Adds unit tests in `tests/test_otel_hook.py` for memory extraction/aggregation, connector behaviors, the batch fast-path skipping tracing init, and the fast JSON loads path.

### Testing
- Ran the unit test suite under `tests/` (via `pytest`) which covers `TestMemoryAggregation`, `TestFastJsonLoads`, and batch buffering behavior; all tests passed.
- Existing otel hook unit tests were retained and exercised the new lazy-load and fast-path code paths successfully.
- Packaging change verified by adding `enrichment_connectors` to `pyproject.toml` and importing it from tests without import errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee83cfa1788328bb4557b481c0c24b)