### PR TITLE
[codex] add Codex hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 > Observability for AI coding agents — any OTLP-compatible backend.
 
-An open-source OpenTelemetry integration that captures AI coding agent activity as structured **traces and logs** and exports them to any OTLP-compatible backend. Works with **any AI coding agent** — today: **Antigravity**, **Claude Code**, **Cursor IDE / Cursor CLI**, **Gemini CLI**, **GitHub Copilot**, and **OpenCode** — using [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
+An open-source OpenTelemetry integration that captures AI coding agent activity as structured **traces and logs** and exports them to any OTLP-compatible backend. Works with **any AI coding agent** — today: **Antigravity**, **Claude Code**, **Codex**, **Cursor IDE / Cursor CLI**, **Gemini CLI**, **GitHub Copilot**, and **OpenCode** — using [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
 
 Every hook event — prompt submissions, tool calls, shell commands, MCP interactions, file edits, subagent orchestration — becomes an OpenTelemetry span you can query, alert on, and visualize in Jaeger, Grafana, Datadog, Honeycomb, Coralogix, or any OTLP-compatible backend.
 
-> **Note**: Claude Code has [native OpenTelemetry support](https://docs.claude.com/en/docs/claude-code/monitoring-usage), but this repo can also be used as a hook target when you want the same hook-based pipeline across all agents.
+> **Note**: Claude Code and Codex have native OpenTelemetry support, but this repo can also be used as a hook target when you want the same hook-based pipeline across all agents. Avoid enabling native Codex OTel export and `otel-hook` for the same events unless you intentionally want duplicate telemetry.
 
 ## How It Works
 
@@ -25,7 +25,7 @@ IDE Event → stdin (JSON) → otel-hook → OpenTelemetry SDK → OTLP Backend
 
 ## Features
 
-- **Multi-IDE Support**: One script, multiple hook providers — `setup.sh` now creates native hook configs for Cursor, GitHub Copilot, and Claude Code without extra IDE override env vars, while the bundled examples cover Copilot/Claude/Cursor for manual installs. The runtime prefers parent-process discovery first, then explicit overrides, then self-reported payload fields, and finally heuristics when needed.
+- **Multi-IDE Support**: One script, multiple hook providers — `setup.sh` and `otel-hook setup` create native hook configs for Codex, Cursor, GitHub Copilot, Claude Code, Gemini CLI, and OpenCode without extra IDE override env vars. The runtime prefers parent-process discovery first, then explicit overrides, then self-reported payload fields, and finally heuristics when needed.
 
 - **Session-level Traces**: Groups all events within a session into a single trace with a 3-tier hierarchy:
 
@@ -58,24 +58,25 @@ gen_ai.client.session (root)
 
 ## Supported Events
 
-| Canonical Name | Antigravity / Claude Code | Cursor IDE / CLI | Gemini CLI | GitHub Copilot | OpenCode (plugin) |
-|---|---|---|---|---|---|
-| `SessionStart` | `SessionStart` | `sessionStart` | `SessionStart` | `sessionStart` | `session.created` |
-| `SessionEnd` | `SessionEnd` | `sessionEnd` | `SessionEnd` | `sessionEnd` | `session.deleted`, `session.error` |
-| `UserPromptSubmit` | `UserPromptSubmit` | `beforeSubmitPrompt` | `BeforeModel` ¹ | `userPromptSubmitted` | `message.updated` (role=user) |
-| `PreToolUse` | `PreToolUse` | `preToolUse` | `BeforeTool` | `preToolUse` | `tool.execute.before` ² |
-| `PostToolUse` | `PostToolUse` | `postToolUse` | `AfterTool` | `postToolUse` | `tool.execute.after` (exit=0) |
-| `PostToolUseFailure` | `PostToolUseFailure` | `postToolUseFailure` | — | — | `tool.execute.after` (exit≠0) |
-| `Stop` | `Stop` | `stop` | `AfterModel` ¹ | — | `session.idle` |
-| `SubagentStart` | `SubagentStart` | `subagentStart` | `BeforeAgent` | — | — ³ |
-| `SubagentStop` | `SubagentStop` | `subagentStop` | `AfterAgent` | — | — ³ |
-| `ErrorOccurred` | — | — | — | `errorOccurred` | — |
-| `BeforeShellExecution` | — | `beforeShellExecution` | — | — | — ² |
-| `AfterShellExecution` | — | `afterShellExecution` | — | — | — ² |
-| `BeforeMCPExecution` | — | `beforeMCPExecution` | — | — | — ² |
-| `AfterMCPExecution` | — | `afterMCPExecution` | — | — | — ² |
-| `BeforeReadFile` | — | `beforeReadFile` | — | — | — ² |
-| `AfterFileEdit` | — | `afterFileEdit` | — | — | `file.edited` |
+| Canonical Name | Antigravity / Claude Code | Codex | Cursor IDE / CLI | Gemini CLI | GitHub Copilot | OpenCode (plugin) |
+|---|---|---|---|---|---|---|
+| `SessionStart` | `SessionStart` | `SessionStart` | `sessionStart` | `SessionStart` | `sessionStart` | `session.created` |
+| `SessionEnd` | `SessionEnd` | — | `sessionEnd` | `SessionEnd` | `sessionEnd` | `session.deleted`, `session.error` |
+| `UserPromptSubmit` | `UserPromptSubmit` | `UserPromptSubmit` | `beforeSubmitPrompt` | `BeforeModel` ¹ | `userPromptSubmitted` | `message.updated` (role=user) |
+| `PreToolUse` | `PreToolUse` | `PreToolUse` | `preToolUse` | `BeforeTool` | `preToolUse` | `tool.execute.before` ² |
+| `PermissionRequest` | — | `PermissionRequest` | — | — | — | — |
+| `PostToolUse` | `PostToolUse` | `PostToolUse` | `postToolUse` | `AfterTool` | `postToolUse` | `tool.execute.after` (exit=0) |
+| `PostToolUseFailure` | `PostToolUseFailure` | — | `postToolUseFailure` | — | — | `tool.execute.after` (exit≠0) |
+| `Stop` | `Stop` | `Stop` | `stop` | `AfterModel` ¹ | — | `session.idle` |
+| `SubagentStart` | `SubagentStart` | — | `subagentStart` | `BeforeAgent` | — | — ³ |
+| `SubagentStop` | `SubagentStop` | — | `subagentStop` | `AfterAgent` | — | — ³ |
+| `ErrorOccurred` | — | — | — | — | `errorOccurred` | — |
+| `BeforeShellExecution` | — | — | `beforeShellExecution` | — | — | — ² |
+| `AfterShellExecution` | — | — | `afterShellExecution` | — | — | — ² |
+| `BeforeMCPExecution` | — | — | `beforeMCPExecution` | — | — | — ² |
+| `AfterMCPExecution` | — | — | `afterMCPExecution` | — | — | — ² |
+| `BeforeReadFile` | — | — | `beforeReadFile` | — | — | — ² |
+| `AfterFileEdit` | — | — | `afterFileEdit` | — | — | `file.edited` |
 
 ¹ Gemini CLI uses `BeforeModel`/`AfterModel` where other agents use `UserPromptSubmit`/`Stop`; the hook normalizes both to canonical span names.<br>
 ² OpenCode routes bash, read, write, MCP, and all other tools through the universal `tool.execute.before/after` hooks, so these events are observable as `PreToolUse`/`PostToolUse` with the appropriate `tool_name`.<br>
@@ -120,9 +121,11 @@ otel-hook setup --agent claude
 otel-hook setup --agent cursor
 otel-hook setup --agent copilot --no-global   # project-scoped (run from repo root)
 otel-hook setup --agent gemini
+otel-hook setup --agent codex
 
 # Project-scoped instead of global
 otel-hook setup --agent cursor --no-global
+otel-hook setup --agent codex --no-global
 
 # Check registration status
 otel-hook diagnose
@@ -258,6 +261,38 @@ cp .cursor/hooks/opentelemetry-hook/examples/antigravity-workflow.example.md .ag
 
 Replace `{{SCRIPT_PATH}}` in the copied workflow with the hook command you want Antigravity to invoke. For a copied-source checkout use `python3 .cursor/hooks/opentelemetry-hook/otel_hook.py`; use `otel-hook` for a pip-installed package.
 
+#### Codex
+
+Codex hooks are configured in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json` and require the `codex_hooks` feature flag in the matching `config.toml`.
+
+**Quick setup (recommended):**
+
+```bash
+# Global — available in every Codex session
+bash setup.sh --codex --global
+
+# Project-level — only active for this project
+bash setup.sh --codex
+```
+
+The setup command enables:
+
+```toml
+[features]
+codex_hooks = true
+```
+
+**Manual install:**
+
+```bash
+mkdir -p .codex
+cp examples/codex-hooks.example.json .codex/hooks.json
+```
+
+Then replace `{{SCRIPT_PATH}}` with `otel-hook` or the absolute source checkout command.
+
+**Events captured:** `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, and `Stop`. Codex does not currently emit a hook-level `SessionEnd`, so unfinished sessions are closed by this hook's stale-session cleanup when needed.
+
 #### OpenCode
 
 A native TypeScript plugin is included at `plugin/opencode.ts`. It hooks into OpenCode's session and tool lifecycle events and pipes JSON payloads to `otel-hook` on stdin — the same pattern used by [rtk](https://github.com/rtk-ai/rtk).
@@ -333,7 +368,7 @@ Then restart your IDE.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `IDE_OTEL_BATCH_ON_STOP` | Enable session-level batching (recommended) | `false` |
-| `IDE_OTEL_IDE_NAME` | Force the detected IDE name (`cursor`, `copilot`, `claude`, `antigravity`, `opencode`) for generic hook runners; common labels like `GitHub Copilot`, `Claude Code`, `Cursor IDE` / `Cursor CLI`, `Anti Gravity`, `OpenCode`, and their `... CLI` / `... IDE` variants normalize automatically | auto-detect |
+| `IDE_OTEL_IDE_NAME` | Force the detected IDE name (`codex`, `cursor`, `copilot`, `claude`, `antigravity`, `opencode`) for generic hook runners; common labels like `OpenAI Codex`, `Codex CLI`, `GitHub Copilot`, `Claude Code`, `Cursor IDE` / `Cursor CLI`, `Anti Gravity`, `OpenCode`, and their `... CLI` / `... IDE` variants normalize automatically | auto-detect |
 | `IDE_OTEL_LOCAL_SPANS` | Save hook spans locally as JSONL files for agent analysis (`.state/local_spans/*.jsonl`) | unset |
 | `IDE_OTEL_CAPTURE_TEXT` | Include prompt/response text in spans | `false` |
 | `IDE_OTEL_MASK_PROMPTS` | Redact emails, tokens, usernames from text | `false` |
@@ -598,7 +633,7 @@ Requires the [Datadog Agent](https://docs.datadoghq.com/opentelemetry/) with OTL
 | Attribute | Description |
 |-----------|-------------|
 | `gen_ai.client.hook.event` | Canonical event name (PascalCase) |
-| `gen_ai.client.name` | Outer IDE or hook host (`cursor`, `copilot`, `claude`, `opencode`, etc.) |
+| `gen_ai.client.name` | Outer IDE or hook host (`codex`, `cursor`, `copilot`, `claude`, `opencode`, etc.) |
 | `gen_ai.client.agent_engine` | Inner agent engine when it differs from the outer IDE (for example Cursor running Claude Code) |
 | `gen_ai.client.session_id` | Session identifier |
 | `gen_ai.client.generation_id` | Generation identifier (Cursor) |
@@ -701,9 +736,10 @@ The hook auto-detects which IDE is calling it:
 |--------|-----|
 | Parent process tree (`ps` parent-chain walk) | Preferred detection for supported IDEs such as Cursor, Copilot / VS Code, Claude Code, and OpenCode |
 | `IDE_OTEL_IDE_NAME` env var | Explicit override for generic hook runners or manual debugging |
-| Self-reported `ide_name`, `client`, or `source_app` values such as `GitHub Copilot`, `GitHub Copilot CLI`, `GitHub Copilot Chat`, `Claude Code`, `Claude Code CLI`, `Anthropic Claude Code`, `Cursor IDE`, `Cursor CLI`, `Anti Gravity`, `Anti Gravity CLI`, or `OpenCode` / `OpenCode CLI` (case-insensitive, hyphen/space-insensitive) | Normalized to the canonical `gen_ai.client.name` |
+| Self-reported `ide_name`, `client`, or `source_app` values such as `OpenAI Codex`, `Codex CLI`, `GitHub Copilot`, `GitHub Copilot CLI`, `GitHub Copilot Chat`, `Claude Code`, `Claude Code CLI`, `Anthropic Claude Code`, `Cursor IDE`, `Cursor CLI`, `Anti Gravity`, `Anti Gravity CLI`, or `OpenCode` / `OpenCode CLI` (case-insensitive, hyphen/space-insensitive) | Normalized to the canonical `gen_ai.client.name` |
 | `conversation_id` or `generation_id` in input | Cursor |
 | `transcript_path`, `permission_mode`, or `notification_type` | Claude Code |
+| `turn_id`, `tool_response`, or `last_assistant_message` | Codex |
 | `session_id` only (no Cursor-specific fields) | GitHub Copilot |
 
 Detection order is: (1) parent process tree, (2) explicit `IDE_OTEL_IDE_NAME`, (3) self-reported payload fields, then (4) heuristics. `setup.sh` now relies on process discovery for generated Cursor, Copilot, and Claude configs, while the env var remains available as an escape hatch for generic runners and debugging.

--- a/examples/codex-hooks.example.json
+++ b/examples/codex-hooks.example.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Template for Codex hooks. Replace {{SCRIPT_PATH}} with the hook command. For a source checkout use 'python3 /absolute/path/to/otel_hook.py'; use 'otel-hook' when installed via pipx or pip. Enable hooks with [features] codex_hooks = true in Codex config.toml.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "{{SCRIPT_PATH}}", "timeout": 30 }]
+      }
+    ]
+  }
+}

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -611,8 +611,13 @@ def _get_os_info() -> dict:
 # ---------------------------------------------------------------------------
 # Client (IDE) version detection
 # ---------------------------------------------------------------------------
+_CODEX_VERSION_CACHE: Optional[str] = None  # sentinel: None = uncached, "" = not found
+_CODEX_VERSION_DETECTED: bool = False
+
+
 def _detect_client_version(data: dict, ide: str) -> Optional[str]:
     """Extract client/IDE version from environment variables or input payload."""
+    global _CODEX_VERSION_CACHE, _CODEX_VERSION_DETECTED
     # Check input payload first
     version = _first_present(data, ("client_version", "ide_version", "app_version"))
     if version:
@@ -631,17 +636,24 @@ def _detect_client_version(data: dict, ide: str) -> Optional[str]:
         if v:
             return v
     if ide == "codex":
-        try:
-            result = subprocess.run(
-                ["codex", "--version"],
-                capture_output=True,
-                text=True,
-                timeout=2,
-            )
-            if result.returncode == 0:
-                return result.stdout.strip()
-        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-            pass
+        v = os.getenv("CODEX_VERSION")
+        if v:
+            return v
+        if not _CODEX_VERSION_DETECTED:
+            _CODEX_VERSION_DETECTED = True
+            try:
+                result = subprocess.run(
+                    ["codex", "--version"],
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+                if result.returncode == 0:
+                    _CODEX_VERSION_CACHE = result.stdout.strip()
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                pass
+        if _CODEX_VERSION_CACHE:
+            return _CODEX_VERSION_CACHE
     # Generic fallback
     v = os.getenv("IDE_OTEL_CLIENT_VERSION")
     if v:
@@ -1541,7 +1553,7 @@ def _maybe_attach_text(span, label: str, text: str) -> None:
 # ---------------------------------------------------------------------------
 _MCP_EVENTS = {"BeforeMCPExecution", "AfterMCPExecution"}
 _SHELL_EVENTS = {"BeforeShellExecution", "AfterShellExecution"}
-_TOOL_EVENTS = {"PreToolUse", "PostToolUse", "PostToolUseFailure"}
+_TOOL_EVENTS = {"PreToolUse", "PostToolUse", "PostToolUseFailure", "PermissionRequest"}
 
 
 def _get_otel_logger(name: str) -> logging.Logger:
@@ -2335,17 +2347,45 @@ def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
         description = tool_input.get("description")
         if isinstance(description, str):
             span.set_attribute("gen_ai.client.approval.description", description)
-        flat_input: dict = {}
-        _flatten(flat_input, "gen_ai.client.tool.input", tool_input)
-        for key, value in flat_input.items():
-            _set_if_present(span, key, value)
+        # Flatten full input only when explicitly opted in (respects privacy controls)
+        if _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")):
+            mask = _safe_bool(os.getenv("IDE_OTEL_MASK_PROMPTS", ""))
+            max_chars = int(os.getenv("IDE_OTEL_TEXT_MAX_CHARS", "4000"))
+            flat_input: dict = {}
+            _flatten(flat_input, "gen_ai.client.tool.input", tool_input)
+            for key, value in flat_input.items():
+                if isinstance(value, str):
+                    if mask:
+                        value = _mask_text(value)
+                    _set_if_present(span, key, value[:max_chars])
+                else:
+                    _set_if_present(span, key, value)
+        else:
+            # Always emit length+digest for cardinality-safe observability
+            text = _stringify(tool_input)
+            span.set_attribute("gen_ai.client.tool.input.length", len(text))
+            span.set_attribute("gen_ai.client.tool.input.sha256", _hash_text(text))
 
     tool_response = data.get("tool_response")
     if isinstance(tool_response, dict):
-        flat_response: dict = {}
-        _flatten(flat_response, "gen_ai.client.tool.response", tool_response)
-        for key, value in flat_response.items():
-            _set_if_present(span, key, value)
+        # Flatten full response only when explicitly opted in
+        if _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")):
+            mask = _safe_bool(os.getenv("IDE_OTEL_MASK_PROMPTS", ""))
+            max_chars = int(os.getenv("IDE_OTEL_TEXT_MAX_CHARS", "4000"))
+            flat_response: dict = {}
+            _flatten(flat_response, "gen_ai.client.tool.response", tool_response)
+            for key, value in flat_response.items():
+                if isinstance(value, str):
+                    if mask:
+                        value = _mask_text(value)
+                    _set_if_present(span, key, value[:max_chars])
+                else:
+                    _set_if_present(span, key, value)
+        else:
+            # Always emit length+digest for cardinality-safe observability
+            text = _stringify(tool_response)
+            span.set_attribute("gen_ai.client.tool.response.length", len(text))
+            span.set_attribute("gen_ai.client.tool.response.sha256", _hash_text(text))
     elif tool_response is not None:
         _maybe_attach_text(span, "tool_response", _stringify(tool_response))
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -611,8 +611,8 @@ def _get_os_info() -> dict:
 # ---------------------------------------------------------------------------
 # Client (IDE) version detection
 # ---------------------------------------------------------------------------
-_CODEX_VERSION_CACHE: Optional[str] = None  # sentinel: None = uncached, "" = not found
-_CODEX_VERSION_DETECTED: bool = False
+_CODEX_VERSION_CACHE: Optional[str] = None  # cached result; None means not yet detected or not found
+_CODEX_VERSION_DETECTED: bool = False  # True once detection has been attempted
 
 
 def _detect_client_version(data: dict, ide: str) -> Optional[str]:
@@ -2347,7 +2347,8 @@ def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
         description = tool_input.get("description")
         if isinstance(description, str):
             span.set_attribute("gen_ai.client.approval.description", description)
-        # Flatten full input only when explicitly opted in (respects privacy controls)
+        # Flatten full input only when explicitly opted in (IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT
+        # gates both tool input and tool response content — consistent with _emit_tool_log).
         if _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")):
             mask = _safe_bool(os.getenv("IDE_OTEL_MASK_PROMPTS", ""))
             max_chars = int(os.getenv("IDE_OTEL_TEXT_MAX_CHARS", "4000"))
@@ -2368,7 +2369,7 @@ def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
 
     tool_response = data.get("tool_response")
     if isinstance(tool_response, dict):
-        # Flatten full response only when explicitly opted in
+        # Flatten full response only when explicitly opted in (same gate as tool input above)
         if _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")):
             mask = _safe_bool(os.getenv("IDE_OTEL_MASK_PROMPTS", ""))
             max_chars = int(os.getenv("IDE_OTEL_TEXT_MAX_CHARS", "4000"))

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -294,6 +294,8 @@ _CANONICAL_EVENT = {
     "AfterTool": "PostToolUse",
     "BeforeAgent": "SubagentStart",
     "AfterAgent": "SubagentStop",
+    # Codex
+    "PermissionRequest": "PermissionRequest",
 }
 
 # ---------------------------------------------------------------------------
@@ -326,6 +328,17 @@ _GEMINI_EVENTS = [
 ]
 _GEMINI_MATCHER_EVENTS = {"BeforeAgent", "AfterAgent", "BeforeModel", "AfterModel", "BeforeTool", "AfterTool"}
 
+_CODEX_EVENTS = [
+    "SessionStart", "PreToolUse", "PermissionRequest", "PostToolUse",
+    "UserPromptSubmit", "Stop",
+]
+_CODEX_MATCHERS = {
+    "SessionStart": "startup|resume|clear",
+    "PreToolUse": "*",
+    "PermissionRequest": "*",
+    "PostToolUse": "*",
+}
+
 # OpenCode plugin — source filename (in plugin/) and destination filename (in plugins/).
 _OPENCODE_PLUGIN_SOURCE_FILENAME = "opencode.ts"
 _OPENCODE_PLUGIN_FILENAME = "otel-hook.ts"
@@ -350,6 +363,9 @@ _INPUT_ALIASES = {
     "toolDefinitions": "tool_definitions",
     "toolUseId": "tool_use_id",
     "toolId": "tool_id",
+    "turnId": "turn_id",
+    "toolResponse": "tool_response",
+    "lastAssistantMessage": "last_assistant_message",
     "agentId": "agent_id",
     "agentName": "agent_name",
     "agentVersion": "agent_version",
@@ -380,8 +396,10 @@ _INPUT_ALIASES = {
 
 # Canonical gen_ai.client.name values accepted directly from IDE_OTEL_IDE_NAME or
 # self-reported payload metadata before alias fallback.
-_CANONICAL_IDE_NAMES = {"cursor", "copilot", "claude", "antigravity", "opencode", "windsurf", "zed", "vscode", "gemini"}
+_CANONICAL_IDE_NAMES = {"cursor", "copilot", "claude", "antigravity", "opencode", "windsurf", "zed", "vscode", "gemini", "codex"}
 _IDE_NAME_ALIASES = {
+    "openai codex": "codex",
+    "codex cli": "codex",
     "github copilot": "copilot",
     "github copilot chat": "copilot",
     "copilot chat": "copilot",
@@ -411,6 +429,7 @@ _GENERATION_END_EVENTS = {"Stop"}
 # GenAI operation mapping (canonical PascalCase)
 _OP_TOOL_EVENTS = {
     "PreToolUse", "PostToolUse", "PostToolUseFailure",
+    "PermissionRequest",
     "BeforeShellExecution", "AfterShellExecution",
     "BeforeMCPExecution", "AfterMCPExecution",
     "BeforeReadFile", "AfterFileEdit",
@@ -435,6 +454,7 @@ _EVENT_ATTR_MAP = {
     "PreToolUse": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id"},
     "PostToolUse": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "duration_ms": "gen_ai.client.duration_ms"},
     "PostToolUseFailure": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "error": "gen_ai.client.error", "is_interrupt": "gen_ai.client.is_interrupt"},
+    "PermissionRequest": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "turn_id": "gen_ai.client.turn_id"},
     "SubagentStart": {"subagent_type": "gen_ai.client.subagent_type", "subagent_task": "gen_ai.client.subagent_task", "agent_id": "gen_ai.client.agent_id", "agent_type": "gen_ai.client.agent_type"},
     "SubagentStop": {"subagent_type": "gen_ai.client.subagent_type", "subagent_task": "gen_ai.client.subagent_task", "status": "gen_ai.client.status", "agent_id": "gen_ai.client.agent_id", "agent_type": "gen_ai.client.agent_type"},
     "Stop": {"status": "gen_ai.client.status", "loop_count": "gen_ai.client.loop_count", "stop_hook_active": "gen_ai.client.stop_hook_active"},
@@ -610,6 +630,18 @@ def _detect_client_version(data: dict, ide: str) -> Optional[str]:
         v = os.getenv("COPILOT_VERSION")
         if v:
             return v
+    if ide == "codex":
+        try:
+            result = subprocess.run(
+                ["codex", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
     # Generic fallback
     v = os.getenv("IDE_OTEL_CLIENT_VERSION")
     if v:
@@ -629,13 +661,16 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
         return "claude"
 
-    raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
-    if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
-        return "claude"
+    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
+        return "codex"
 
     reported = _normalize_ide_name(_first_present(data, ("ide_name", "ide", "client", "source_app")))
     if reported:
         return reported
+
+    raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
+    if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
+        return "claude"
 
     return None
 
@@ -1781,6 +1816,8 @@ def _detect_ide_from_process_tree() -> Optional[str]:
                 return "cursor"
             if "opencode" in comm:
                 return "opencode"
+            if comm.endswith("codex") or comm.endswith("/codex") or "codex" in comm:
+                return "codex"
             if ("code helper" in comm or comm.endswith("/code") or
                     "visual studio code" in comm):
                 return "copilot"
@@ -1825,6 +1862,9 @@ def _detect_ide(data: dict) -> str:
 
     if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
         return "claude"
+
+    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
+        return "codex"
 
     raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
     if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
@@ -2249,6 +2289,7 @@ def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Opt
     _emit_event_log(event_name, data)
     _set_if_present(span, "gen_ai.client.session_id", data.get("session_id") or data.get("conversation_id"))
     _set_if_present(span, "gen_ai.client.generation_id", data.get("generation_id"))
+    _set_if_present(span, "gen_ai.client.turn_id", data.get("turn_id"))
     span.set_attribute("gen_ai.client.timestamp", datetime.now(timezone.utc).isoformat())
     span.set_attribute("gen_ai.client.workspace", data.get("cwd") or os.getcwd())
 
@@ -2267,6 +2308,7 @@ def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Opt
     mapping = _EVENT_ATTR_MAP.get(event_name, {})
     for key, attr in mapping.items():
         _set_if_present(span, attr, data.get(key))
+    _set_codex_tool_attrs(span, event_name, data)
 
     # Text fields
     for label in ("prompt", "response"):
@@ -2278,6 +2320,34 @@ def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Opt
         value = data.get(label)
         if value is not None and not isinstance(value, dict):
             _maybe_attach_text(span, label, _stringify(value))
+
+
+def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
+    """Attach useful attributes from Codex's structured tool hook payloads."""
+    if event_name not in {"PreToolUse", "PermissionRequest", "PostToolUse"}:
+        return
+
+    tool_input = data.get("tool_input")
+    if isinstance(tool_input, dict):
+        command = tool_input.get("command")
+        if isinstance(command, str):
+            span.set_attribute("gen_ai.client.command", command)
+        description = tool_input.get("description")
+        if isinstance(description, str):
+            span.set_attribute("gen_ai.client.approval.description", description)
+        flat_input: dict = {}
+        _flatten(flat_input, "gen_ai.client.tool.input", tool_input)
+        for key, value in flat_input.items():
+            _set_if_present(span, key, value)
+
+    tool_response = data.get("tool_response")
+    if isinstance(tool_response, dict):
+        flat_response: dict = {}
+        _flatten(flat_response, "gen_ai.client.tool.response", tool_response)
+        for key, value in flat_response.items():
+            _set_if_present(span, key, value)
+    elif tool_response is not None:
+        _maybe_attach_text(span, "tool_response", _stringify(tool_response))
 
 
 def _flatten(out: dict, prefix: str, data: dict) -> None:
@@ -2627,7 +2697,7 @@ def main() -> int:
 # Setup CLI: helpers
 # ---------------------------------------------------------------------------
 
-_REPO_MARKERS = (".git", ".github", ".cursor", ".claude", ".gemini", ".opencode")
+_REPO_MARKERS = (".git", ".github", ".cursor", ".claude", ".gemini", ".codex", ".opencode")
 
 
 def _find_repo_root(cwd: str) -> str:
@@ -2684,6 +2754,50 @@ def _write_json_file(path: str, data: dict) -> None:
         f.write("\n")
 
 
+def _ensure_toml_bool(path: str, section: str, key: str, value: bool) -> None:
+    """Set a boolean in a simple TOML section while preserving unrelated text."""
+    desired = "true" if value else "false"
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if os.path.exists(path):
+        with open(path) as f:
+            lines = f.readlines()
+    else:
+        lines = []
+
+    section_header = f"[{section}]"
+    section_start = None
+    section_end = len(lines)
+    section_re = re.compile(r"^\s*\[.*\]\s*$")
+    for index, line in enumerate(lines):
+        if line.strip() == section_header:
+            section_start = index
+            section_end = len(lines)
+            for probe in range(index + 1, len(lines)):
+                if section_re.match(lines[probe]):
+                    section_end = probe
+                    break
+            break
+
+    new_line = f"{key} = {desired}\n"
+    if section_start is None:
+        if lines and lines[-1].strip():
+            lines.append("\n")
+        lines.extend([f"{section_header}\n", new_line])
+    else:
+        key_re = re.compile(rf"^\s*{re.escape(key)}\s*=")
+        for index in range(section_start + 1, section_end):
+            if key_re.match(lines[index]):
+                if lines[index] == new_line:
+                    return
+                lines[index] = new_line
+                break
+        else:
+            lines.insert(section_end, new_line)
+
+    with open(path, "w") as f:
+        f.writelines(lines)
+
+
 def _detect_available_agents() -> list:
     """Return list of agent names whose home dirs or commands exist."""
     found = []
@@ -2699,6 +2813,8 @@ def _detect_available_agents() -> list:
         found.append("gemini")
     if shutil.which("opencode") or os.path.isdir(os.path.join(home, ".config", "opencode")):
         found.append("opencode")
+    if os.path.isdir(os.path.join(home, ".codex")) or shutil.which("codex"):
+        found.append("codex")
     return found
 
 
@@ -2918,6 +3034,75 @@ def setup_gemini(global_: bool = True, cwd: str = ".") -> None:
     _log_setup_result("gemini", settings_path, added, updated, skipped)
 
 
+def setup_codex(global_: bool = True, cwd: str = ".") -> None:
+    """Register otel-hook in Codex's hooks.json and enable Codex hooks."""
+    hook_cmd = _resolve_hook_cmd()
+    if global_:
+        codex_dir = os.path.join(os.path.expanduser("~"), ".codex")
+    else:
+        repo = _find_repo_root(cwd)
+        codex_dir = os.path.join(repo, ".codex")
+
+    hooks_path = os.path.join(codex_dir, "hooks.json")
+    config_path = os.path.join(codex_dir, "config.toml")
+    _ensure_toml_bool(config_path, "features", "codex_hooks", True)
+
+    doc = _load_json_file(hooks_path)
+    hooks = doc.setdefault("hooks", {})
+    added, updated, skipped = [], [], []
+
+    for event in _CODEX_EVENTS:
+        event_list = hooks.setdefault(event, [])
+        matcher = _CODEX_MATCHERS.get(event)
+        matches = []
+        for entry in event_list:
+            if matcher is not None and entry.get("matcher", "") != matcher:
+                continue
+            if matcher is None and "matcher" in entry:
+                continue
+            for h in entry.get("hooks", []):
+                cmd = h.get("command", "")
+                if "otel_hook" in cmd or "otel-hook" in cmd:
+                    matches.append(h)
+
+        if matches:
+            changed = False
+            for hook in matches:
+                if hook.get("command") != hook_cmd:
+                    hook["command"] = hook_cmd
+                    changed = True
+                if hook.get("type") != "command":
+                    hook["type"] = "command"
+                    changed = True
+                if "timeout" not in hook:
+                    hook["timeout"] = 30
+                    changed = True
+                env = hook.get("env")
+                if isinstance(env, dict) and "IDE_OTEL_IDE_NAME" in env:
+                    env = dict(env)
+                    env.pop("IDE_OTEL_IDE_NAME", None)
+                    if env:
+                        hook["env"] = env
+                    else:
+                        hook.pop("env", None)
+                    changed = True
+            (updated if changed else skipped).append(event)
+            continue
+
+        hook_entry: dict = {
+            "hooks": [{"type": "command", "command": hook_cmd, "timeout": 30}]
+        }
+        if matcher is not None:
+            hook_entry["matcher"] = matcher
+        event_list.append(hook_entry)
+        added.append(event)
+
+    _write_json_file(hooks_path, doc)
+    if added or updated:
+        click.echo(f"  ✓ [codex] Enabled hooks feature ({config_path})")
+    _log_setup_result("codex", hooks_path, added, updated, skipped)
+
+
 def setup_opencode(global_: bool = True, cwd: str = ".") -> None:
     """Install the otel-hook TypeScript plugin into OpenCode's plugins directory.
 
@@ -2970,6 +3155,8 @@ def setup_agent(agent: str, global_: bool = True, cwd: str = ".") -> None:
         setup_copilot(cwd=cwd)
     elif agent == "gemini":
         setup_gemini(global_=global_, cwd=cwd)
+    elif agent == "codex":
+        setup_codex(global_=global_, cwd=cwd)
     elif agent == "opencode":
         setup_opencode(global_=global_, cwd=cwd)
     else:
@@ -3007,7 +3194,7 @@ def cli(ctx: click.Context) -> None:
 @cli.command("setup")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "codex", "opencode"]),
     multiple=True,
     help="Agent to configure. Omit to auto-detect all available agents.",
 )
@@ -3019,7 +3206,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
     """Register otel-hook in one or more AI agent configs."""
     targets = list(agents) or _detect_available_agents()
     if not targets:
-        click.echo("No agents detected. Use --agent cursor|claude|copilot|gemini|opencode to specify one.", err=True)
+        click.echo("No agents detected. Use --agent cursor|claude|copilot|gemini|codex|opencode to specify one.", err=True)
         raise SystemExit(1)
     errors = []
     for agent in targets:
@@ -3038,7 +3225,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @cli.command("diagnose")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "codex", "opencode"]),
     multiple=True,
     help="Agent to check. Omit to check all.",
 )
@@ -3046,7 +3233,7 @@ def setup_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @click.option("--cwd", default=".")
 def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
     """Show hook registration status for each agent."""
-    targets = list(agents) or ["cursor", "claude", "copilot", "gemini", "opencode"]
+    targets = list(agents) or ["cursor", "claude", "copilot", "gemini", "codex", "opencode"]
     home = os.path.expanduser("~")
 
     paths = {
@@ -3054,6 +3241,7 @@ def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
         "claude": os.path.join(home, ".claude", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".claude", "settings.json"),
         "copilot": os.path.join(_find_repo_root(cwd), ".github", "hooks", "otel-hooks.json"),
         "gemini": os.path.join(home, ".gemini", "settings.json") if global_ else os.path.join(_find_repo_root(cwd), ".gemini", "settings.json"),
+        "codex": os.path.join(home, ".codex", "hooks.json") if global_ else os.path.join(_find_repo_root(cwd), ".codex", "hooks.json"),
         "opencode": (
             os.path.join(home, ".config", "opencode", "plugins", _OPENCODE_PLUGIN_FILENAME)
             if global_ else
@@ -3094,7 +3282,7 @@ def diagnose_cmd(agents: tuple, global_: bool, cwd: str) -> None:
 @cli.command("uninstall")
 @click.option(
     "--agent", "agents",
-    type=click.Choice(["cursor", "claude", "copilot", "gemini", "opencode"]),
+    type=click.Choice(["cursor", "claude", "copilot", "gemini", "codex", "opencode"]),
     multiple=True,
     required=True,
 )
@@ -3188,6 +3376,30 @@ def uninstall_cmd(agents: tuple, global_: bool, cwd: str) -> None:
             if removed:
                 _write_json_file(path, settings)
             click.echo(f"  {'✓' if removed else '·'} [gemini] Removed {removed} entries ({path})")
+
+        elif agent == "codex":
+            path = os.path.join(home, ".codex", "hooks.json") if global_ else os.path.join(_find_repo_root(cwd), ".codex", "hooks.json")
+            doc = _load_json_file(path)
+            hooks = doc.get("hooks", {})
+            removed = 0
+            for event in list(hooks.keys()):
+                new_list = []
+                for entry in hooks[event]:
+                    before = len(entry.get("hooks", []))
+                    surviving = [
+                        h for h in entry.get("hooks", [])
+                        if "otel-hook" not in h.get("command", "") and "otel_hook" not in h.get("command", "")
+                    ]
+                    removed += before - len(surviving)
+                    if surviving:
+                        entry["hooks"] = surviving
+                        new_list.append(entry)
+                hooks[event] = new_list
+                if not hooks[event]:
+                    del hooks[event]
+            if removed:
+                _write_json_file(path, doc)
+            click.echo(f"  {'✓' if removed else '·'} [codex] Removed {removed} entries ({path})")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "opentelemetry-hooks"
 dynamic = ["version"]
-description = "OpenTelemetry integration for AI coding agents (Cursor IDE/CLI, GitHub Copilot, Claude Code, Antigravity, OpenCode-compatible runners)"
+description = "OpenTelemetry integration for AI coding agents (Codex, Cursor IDE/CLI, GitHub Copilot, Claude Code, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
-keywords = ["opentelemetry", "observability", "ai-agents", "claude", "copilot", "cursor", "gemini", "telemetry", "hooks", "tracing"]
+keywords = ["opentelemetry", "observability", "ai-agents", "codex", "claude", "copilot", "cursor", "gemini", "telemetry", "hooks", "tracing"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",
@@ -46,6 +46,7 @@ py-modules = ["otel_hook", "enrichment_connectors"]
 "share/opentelemetry-hooks/examples" = [
     "examples/antigravity-workflow.example.md",
     "examples/claude-hooks.example.json",
+    "examples/codex-hooks.example.json",
     "examples/copilot-hooks.example.json",
     "examples/cursor-hooks.example.json",
     "examples/hooks.example.json",

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,8 @@
 #   bash setup.sh --copilot          # GitHub Copilot (.github/hooks/otel-hooks.json)
 #   bash setup.sh --claude           # Claude Code only
 #   bash setup.sh --claude --global  # Claude Code global (~/.claude/settings.json)
+#   bash setup.sh --codex            # Codex project-level (.codex/hooks.json)
+#   bash setup.sh --codex --global   # Codex global (~/.codex/hooks.json)
 #   bash setup.sh --opencode         # OpenCode project-level (.opencode/plugins/)
 #   bash setup.sh --opencode --global # OpenCode global (~/.config/opencode/plugins/)
 #   bash setup.sh --reinstall        # pipx install --force . then register hooks
@@ -61,7 +63,12 @@ COPILOT_EVENTS=(
   errorOccurred
 )
 
-REPO_MARKERS=(.git .github .cursor .claude .opencode .gemini)
+CODEX_EVENTS=(
+  SessionStart PreToolUse PermissionRequest
+  PostToolUse UserPromptSubmit Stop
+)
+
+REPO_MARKERS=(.git .github .cursor .claude .opencode .gemini .codex)
 
 # Events that require a matcher (Claude Code tool-related hooks)
 CLAUDE_MATCHER_EVENTS="PreToolUse PostToolUse PostToolUseFailure"
@@ -73,10 +80,12 @@ DO_COPILOT=""
 DO_CLAUDE=""
 DO_OPENCODE=""
 DO_GEMINI=""
+DO_CODEX=""
 CURSOR_GLOBAL=""
 CLAUDE_GLOBAL=""
 OPENCODE_GLOBAL=""
 GEMINI_GLOBAL=""
+CODEX_GLOBAL=""
 WANT_GLOBAL=""
 DO_REINSTALL=""
 DO_CLEAN=""
@@ -90,6 +99,7 @@ while [[ $# -gt 0 ]]; do
     --claude)    DO_CLAUDE=1; shift ;;
     --opencode)  DO_OPENCODE=1; shift ;;
     --gemini)    DO_GEMINI=1; shift ;;
+    --codex)      DO_CODEX=1; shift ;;
     --global)    WANT_GLOBAL=1; shift ;;
     --reinstall) DO_REINSTALL=1; shift ;;
     --clean)     DO_CLEAN=1; shift ;;
@@ -103,8 +113,8 @@ done
 # Requiring an explicit IDE flag avoids accidentally installing global hooks
 # for IDEs the user did not intend to configure.
 if [[ -n "$WANT_GLOBAL" ]]; then
-  if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" ]]; then
-    echo "Error: --global requires an explicit IDE flag (--cursor, --copilot, --claude, --gemini, or --opencode)."
+  if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" && -z "$DO_CODEX" ]]; then
+    echo "Error: --global requires an explicit IDE flag (--cursor, --copilot, --claude, --gemini, --codex, or --opencode)."
     exit 1
   fi
   if [[ -n "$DO_COPILOT" ]]; then
@@ -115,10 +125,11 @@ if [[ -n "$WANT_GLOBAL" ]]; then
   [[ -n "$DO_CLAUDE" ]]   && CLAUDE_GLOBAL=1
   [[ -n "$DO_OPENCODE" ]] && OPENCODE_GLOBAL=1
   [[ -n "$DO_GEMINI" ]]   && GEMINI_GLOBAL=1
+  [[ -n "$DO_CODEX" ]]    && CODEX_GLOBAL=1
 fi
 
 # Auto-detect if no IDE flags given (applies both for setup and for operational commands)
-if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" ]]; then
+if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" && -z "$DO_CODEX" ]]; then
   # Check for a .cursor workspace directory in the current or parent directories,
   # or fallback to cursor being installed on PATH or in $HOME.
   CURSOR_DIR_FOUND=""
@@ -158,11 +169,16 @@ if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE
     DO_GEMINI=1
     GEMINI_GLOBAL=1
   fi
-  if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" ]]; then
+  # Check if Codex is installed
+  if command -v codex &>/dev/null || [ -d "$HOME/.codex" ]; then
+    DO_CODEX=1
+    CODEX_GLOBAL=1
+  fi
+  if [[ -z "$DO_CURSOR" && -z "$DO_COPILOT" && -z "$DO_CLAUDE" && -z "$DO_OPENCODE" && -z "$DO_GEMINI" && -z "$DO_CODEX" ]]; then
     if [[ -n "$DO_CLEAN" || -n "$DO_UNINSTALL" || -n "$DO_DIAGNOSE" ]]; then
-      echo "No supported IDE detected. Use --cursor, --copilot, --claude, --gemini, or --opencode to target a specific IDE."
+      echo "No supported IDE detected. Use --cursor, --copilot, --claude, --gemini, --codex, or --opencode to target a specific IDE."
     else
-      echo "No supported IDE detected. Use --cursor, --copilot, --claude, --gemini, or --opencode to force setup."
+      echo "No supported IDE detected. Use --cursor, --copilot, --claude, --gemini, --codex, or --opencode to force setup."
     fi
     exit 1
   fi
@@ -800,6 +816,197 @@ if skipped:
 " "$settings_json" "$HOOK_CMD" "${GEMINI_EVENTS[@]}"
 }
 
+# ─── Codex setup / cleanup ──────────────────────────────────────────────────
+setup_codex() {
+  local hooks_json
+  local config_toml
+  if [[ -n "$CODEX_GLOBAL" ]]; then
+    hooks_json="$HOME/.codex/hooks.json"
+    config_toml="$HOME/.codex/config.toml"
+    echo "📦 Codex (global: $hooks_json)"
+  else
+    local repo_root
+    repo_root="$(find_repo_root)"
+    hooks_json="$repo_root/.codex/hooks.json"
+    config_toml="$repo_root/.codex/config.toml"
+    echo "📦 Codex (project: $hooks_json)"
+  fi
+  mkdir -p "$(dirname "$hooks_json")"
+
+  python3 -c "
+import json, os, re, sys
+
+hooks_path, config_path, hook_cmd = sys.argv[1:4]
+events = sys.argv[4:]
+matchers = {
+    'SessionStart': 'startup|resume|clear',
+    'PreToolUse': '*',
+    'PermissionRequest': '*',
+    'PostToolUse': '*',
+}
+
+os.makedirs(os.path.dirname(config_path), exist_ok=True)
+lines = []
+if os.path.exists(config_path):
+    with open(config_path) as f:
+        lines = f.readlines()
+section_start = None
+section_end = len(lines)
+section_re = re.compile(r'^\s*\[.*\]\s*$')
+for index, line in enumerate(lines):
+    if line.strip() == '[features]':
+        section_start = index
+        for probe in range(index + 1, len(lines)):
+            if section_re.match(lines[probe]):
+                section_end = probe
+                break
+        break
+if section_start is None:
+    if lines and lines[-1].strip():
+        lines.append('\n')
+    lines.extend(['[features]\n', 'codex_hooks = true\n'])
+else:
+    key_re = re.compile(r'^\s*codex_hooks\s*=')
+    for index in range(section_start + 1, section_end):
+        if key_re.match(lines[index]):
+            lines[index] = 'codex_hooks = true\n'
+            break
+    else:
+        lines.insert(section_end, 'codex_hooks = true\n')
+with open(config_path, 'w') as f:
+    f.writelines(lines)
+
+if os.path.exists(hooks_path):
+    with open(hooks_path) as f:
+        try:
+            doc = json.load(f)
+        except json.JSONDecodeError:
+            doc = {}
+else:
+    doc = {}
+hooks = doc.setdefault('hooks', {})
+added, updated, skipped = [], [], []
+for event in events:
+    event_list = hooks.setdefault(event, [])
+    matcher = matchers.get(event)
+    matches = []
+    for entry in event_list:
+        if matcher is not None and entry.get('matcher', '') != matcher:
+            continue
+        if matcher is None and 'matcher' in entry:
+            continue
+        for h in entry.get('hooks', []):
+            cmd = h.get('command', '')
+            if 'otel_hook' in cmd or 'otel-hook' in cmd:
+                matches.append(h)
+    if matches:
+        changed = False
+        for hook in matches:
+            if hook.get('command') != hook_cmd:
+                hook['command'] = hook_cmd
+                changed = True
+            if hook.get('type') != 'command':
+                hook['type'] = 'command'
+                changed = True
+            if 'timeout' not in hook:
+                hook['timeout'] = 30
+                changed = True
+        (updated if changed else skipped).append(event)
+        continue
+    entry = {'hooks': [{'type': 'command', 'command': hook_cmd, 'timeout': 30}]}
+    if matcher is not None:
+        entry['matcher'] = matcher
+    event_list.append(entry)
+    added.append(event)
+with open(hooks_path, 'w') as f:
+    json.dump(doc, f, indent=2)
+    f.write('\n')
+print(f'  ✅ Enabled Codex hooks feature ({config_path})')
+if added:
+    print(f'  ✅ Added OTel hook to {len(added)} events: {\", \".join(added)}')
+if updated:
+    print(f'  ✅ Updated OTel hook path in {len(updated)} events: {\", \".join(updated)}')
+if skipped:
+    print(f'  ⏭️  Already registered in {len(skipped)} events (no changes)')
+" "$hooks_json" "$config_toml" "$HOOK_CMD" "${CODEX_EVENTS[@]}"
+}
+
+diagnose_codex() {
+  local hooks_json
+  if [[ -n "$CODEX_GLOBAL" ]]; then
+    hooks_json="$HOME/.codex/hooks.json"
+    echo "🔍 Codex (global: $hooks_json)"
+  else
+    local repo_root
+    repo_root="$(find_repo_root)"
+    hooks_json="$repo_root/.codex/hooks.json"
+    echo "🔍 Codex (project: $hooks_json)"
+  fi
+  if [ ! -f "$hooks_json" ]; then
+    echo "  ⏭️  Hooks file not found"
+    return 0
+  fi
+  python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    doc = json.load(f)
+count = 0
+for entries in doc.get('hooks', {}).values():
+    for entry in entries:
+        for h in entry.get('hooks', []):
+            cmd = h.get('command', '')
+            if 'otel_hook' in cmd or 'otel-hook' in cmd:
+                count += 1
+print(f'  {\"✅\" if count else \"⏭️\"} {count} OTel hook entries registered' if count else '  ⏭️  No OTel hook entries found')
+" "$hooks_json"
+}
+
+uninstall_codex() {
+  local hooks_json
+  if [[ -n "$CODEX_GLOBAL" ]]; then
+    hooks_json="$HOME/.codex/hooks.json"
+    echo "🗑️  Codex (global: $hooks_json)"
+  else
+    local repo_root
+    repo_root="$(find_repo_root)"
+    hooks_json="$repo_root/.codex/hooks.json"
+    echo "🗑️  Codex (project: $hooks_json)"
+  fi
+  if [ ! -f "$hooks_json" ]; then
+    echo "  ⏭️  Hooks file not found — nothing to uninstall"
+    return 0
+  fi
+  python3 -c "
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    doc = json.load(f)
+hooks = doc.get('hooks', {})
+removed = 0
+for event, entries in list(hooks.items()):
+    live = []
+    for entry in entries:
+        before = len(entry.get('hooks', []))
+        surviving = [h for h in entry.get('hooks', []) if 'otel-hook' not in h.get('command', '') and 'otel_hook' not in h.get('command', '')]
+        removed += before - len(surviving)
+        if surviving:
+            entry['hooks'] = surviving
+            live.append(entry)
+    hooks[event] = live
+    if not hooks[event]:
+        del hooks[event]
+if removed:
+    with open(path, 'w') as f:
+        json.dump(doc, f, indent=2)
+        f.write('\n')
+print(f'  ✅ Uninstalled {removed} hook entries' if removed else '  ⏭️  No OTel hook entries found to uninstall')
+" "$hooks_json"
+}
+
+clean_codex() {
+  diagnose_codex
+}
+
 # ─── Claude Code cleanup ────────────────────────────────────────────────────
 diagnose_claude() {
   local settings_json
@@ -1388,6 +1595,7 @@ if [[ -n "$DO_DIAGNOSE" ]]; then
   [[ -n "$DO_CLAUDE" ]] && diagnose_claude
   [[ -n "$DO_COPILOT" ]] && diagnose_copilot
   [[ -n "$DO_GEMINI" ]] && diagnose_gemini
+  [[ -n "$DO_CODEX" ]] && diagnose_codex
   exit 0
 fi
 
@@ -1397,6 +1605,7 @@ if [[ -n "$DO_UNINSTALL" ]]; then
   [[ -n "$DO_CLAUDE" ]] && uninstall_claude
   [[ -n "$DO_COPILOT" ]] && uninstall_copilot
   [[ -n "$DO_GEMINI" ]] && uninstall_gemini
+  [[ -n "$DO_CODEX" ]] && uninstall_codex
   echo "✅ Uninstall complete!"
   exit 0
 fi
@@ -1407,6 +1616,7 @@ if [[ -n "$DO_CLEAN" ]]; then
   [[ -n "$DO_CLAUDE" ]] && clean_claude
   [[ -n "$DO_COPILOT" ]] && clean_copilot
   [[ -n "$DO_GEMINI" ]] && clean_gemini
+  [[ -n "$DO_CODEX" ]] && clean_codex
   echo "✅ Cleaning complete!"
   exit 0
 fi
@@ -1436,6 +1646,11 @@ if [[ -n "$DO_GEMINI" ]]; then
   echo ""
 fi
 
+if [[ -n "$DO_CODEX" ]]; then
+  setup_codex
+  echo ""
+fi
+
 # ─── Kick off venv provisioning ─────────────────────────────────────────────
 echo "🚀 Bootstrapping Python venv (runs in background) ..."
 echo '{}' | python3 "$HOOK_DIR/otel_hook.py" > /dev/null 2>&1 || true
@@ -1460,6 +1675,9 @@ if [[ -n "$DO_COPILOT" ]]; then
 fi
 if [[ -n "$DO_OPENCODE" ]]; then
   echo "  2. Restart OpenCode to activate the plugin"
+fi
+if [[ -n "$DO_CODEX" ]]; then
+  echo "  2. Restart Codex to activate hooks"
 fi
 # Determine the hook home used for logging: prefer IDE_OTEL_HOOK_HOME, then
 # fall back to the system default for otel-hook, or the local script dir.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ import os
 from click.testing import CliRunner
 
 import otel_hook
-from otel_hook import cli, setup_cursor, setup_claude, setup_copilot, setup_gemini
+from otel_hook import cli, setup_cursor, setup_claude, setup_copilot, setup_gemini, setup_codex
 
 
 # ---------------------------------------------------------------------------
@@ -229,6 +229,43 @@ class TestSetupGemini:
 
 
 # ---------------------------------------------------------------------------
+# setup_codex
+# ---------------------------------------------------------------------------
+
+class TestSetupCodex:
+    def test_creates_hooks_and_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_codex(global_=False, cwd=str(tmp_path))
+        hooks_path = tmp_path / ".codex" / "hooks.json"
+        config_path = tmp_path / ".codex" / "config.toml"
+        assert hooks_path.exists()
+        assert config_path.exists()
+        doc = _read(str(hooks_path))
+        assert "PermissionRequest" in doc["hooks"]
+        assert "codex_hooks = true" in config_path.read_text()
+
+    def test_matchers_only_where_supported(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_codex(global_=False, cwd=str(tmp_path))
+        doc = _read(str(tmp_path / ".codex" / "hooks.json"))
+        assert doc["hooks"]["SessionStart"][0]["matcher"] == "startup|resume|clear"
+        assert doc["hooks"]["PreToolUse"][0]["matcher"] == "*"
+        assert "matcher" not in doc["hooks"]["UserPromptSubmit"][0]
+        assert "matcher" not in doc["hooks"]["Stop"][0]
+
+    def test_preserves_existing_config(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        config_path = tmp_path / ".codex" / "config.toml"
+        os.makedirs(str(config_path.parent))
+        config_path.write_text('model = "gpt-5.5"\n\n[features]\nmemories = true\n')
+        setup_codex(global_=False, cwd=str(tmp_path))
+        text = config_path.read_text()
+        assert 'model = "gpt-5.5"' in text
+        assert "memories = true" in text
+        assert "codex_hooks = true" in text
+
+
+# ---------------------------------------------------------------------------
 # CLI setup command
 # ---------------------------------------------------------------------------
 
@@ -284,6 +321,14 @@ class TestDiagnoseCmd:
         assert result.exit_code == 0
         assert "events registered" in result.output
 
+    def test_codex_registered(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_codex(global_=False, cwd=str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["diagnose", "--agent", "codex", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "events registered" in result.output
+
 
 # ---------------------------------------------------------------------------
 # CLI uninstall command
@@ -305,3 +350,12 @@ class TestUninstallCmd:
         runner = CliRunner()
         result = runner.invoke(cli, ["uninstall", "--agent", "cursor", "--no-global", "--cwd", str(tmp_path)])
         assert result.exit_code == 0
+
+    def test_uninstall_codex(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        setup_codex(global_=False, cwd=str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "--agent", "codex", "--no-global", "--cwd", str(tmp_path)])
+        assert result.exit_code == 0
+        doc = _read(str(tmp_path / ".codex" / "hooks.json"))
+        assert doc.get("hooks", {}) == {}

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -282,6 +282,16 @@ class TestDetectIDE:
     def test_opencode_cli_self_reported_name(self):
         assert otel_hook._detect_ide({"source_app": "OpenCode CLI"}) == "opencode"
 
+    def test_codex_env_override(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_IDE_NAME", "OpenAI Codex")
+        assert otel_hook._detect_ide({"session_id": "sess-1"}) == "codex"
+
+    def test_codex_cli_self_reported_name(self):
+        assert otel_hook._detect_ide({"source_app": "Codex CLI"}) == "codex"
+
+    def test_codex_via_turn_id(self):
+        assert otel_hook._detect_ide({"hook_event_name": "PreToolUse", "session_id": "sess-1", "turn_id": "turn-1"}) == "codex"
+
     def test_antigravity_spaced_self_reported_name(self):
         assert otel_hook._detect_ide({"source_app": "Anti Gravity"}) == "antigravity"
 
@@ -1685,3 +1695,40 @@ class TestSetupOpencode:
         monkeypatch.setattr(otel_hook, "setup_opencode", lambda global_, cwd: called.append((global_, cwd)))
         otel_hook.setup_agent("opencode", global_=True, cwd="/tmp")
         assert called == [(True, "/tmp")]
+
+
+# ---------------------------------------------------------------------------
+# setup_codex
+# ---------------------------------------------------------------------------
+
+class TestSetupCodex:
+    def test_project_install_creates_hooks_and_config(self, tmp_path, monkeypatch):
+        (tmp_path / ".git").mkdir()
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        otel_hook.setup_codex(global_=False, cwd=str(tmp_path))
+        hooks_path = tmp_path / ".codex" / "hooks.json"
+        config_path = tmp_path / ".codex" / "config.toml"
+        assert hooks_path.is_file()
+        assert config_path.is_file()
+        doc = json.loads(hooks_path.read_text())
+        assert set(otel_hook._CODEX_EVENTS).issubset(doc["hooks"])
+        assert "codex_hooks = true" in config_path.read_text()
+
+    def test_global_install_uses_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook, "_resolve_hook_cmd", lambda: "otel-hook")
+        otel_hook.setup_codex(global_=True)
+        assert (tmp_path / ".codex" / "hooks.json").is_file()
+
+    def test_detect_available_agents_includes_codex_when_config_exists(self, tmp_path, monkeypatch):
+        (tmp_path / ".codex").mkdir()
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(otel_hook.shutil, "which", lambda cmd: None)
+        found = otel_hook._detect_available_agents()
+        assert "codex" in found
+
+    def test_setup_agent_dispatches_to_codex(self, monkeypatch):
+        called = []
+        monkeypatch.setattr(otel_hook, "setup_codex", lambda global_, cwd: called.append((global_, cwd)))
+        otel_hook.setup_agent("codex", global_=False, cwd="/tmp/project")
+        assert called == [(False, "/tmp/project")]

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1416,6 +1416,82 @@ class TestDetectClientVersion:
         monkeypatch.delenv("IDE_OTEL_CLIENT_VERSION", raising=False)
         assert otel_hook._detect_client_version({}, "claude") is None
 
+    def test_codex_from_env(self, monkeypatch):
+        monkeypatch.setenv("CODEX_VERSION", "1.5.0")
+        monkeypatch.setattr(otel_hook, "_CODEX_VERSION_DETECTED", False)
+        monkeypatch.setattr(otel_hook, "_CODEX_VERSION_CACHE", None)
+        assert otel_hook._detect_client_version({}, "codex") == "1.5.0"
+
+    def test_codex_subprocess_cached(self, monkeypatch):
+        """codex --version subprocess must only be called once per process."""
+        monkeypatch.delenv("CODEX_VERSION", raising=False)
+        monkeypatch.delenv("IDE_OTEL_CLIENT_VERSION", raising=False)
+        monkeypatch.setattr(otel_hook, "_CODEX_VERSION_DETECTED", False)
+        monkeypatch.setattr(otel_hook, "_CODEX_VERSION_CACHE", None)
+        call_count = []
+
+        import subprocess as _sp
+        real_run = _sp.run
+
+        def fake_run(args, **kwargs):
+            if args == ["codex", "--version"]:
+                call_count.append(1)
+                class R:
+                    returncode = 0
+                    stdout = "2.0.0\n"
+                return R()
+            return real_run(args, **kwargs)
+
+        monkeypatch.setattr(_sp, "run", fake_run)
+        assert otel_hook._detect_client_version({}, "codex") == "2.0.0"
+        assert otel_hook._detect_client_version({}, "codex") == "2.0.0"
+        assert len(call_count) == 1, "subprocess must only be invoked once"
+
+
+class _FakeSpan:
+    """Minimal span stub for testing attribute helpers."""
+    def __init__(self):
+        self.attrs = {}
+
+    def set_attribute(self, key, value):
+        self.attrs[key] = value
+
+
+class TestSetCodexToolAttrs:
+    def test_default_emits_digest_not_content(self, monkeypatch):
+        monkeypatch.delenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", raising=False)
+        span = _FakeSpan()
+        data = {"tool_input": {"command": "ls", "path": "/tmp"}, "tool_response": {"output": "file.txt"}}
+        otel_hook._set_codex_tool_attrs(span, "PreToolUse", data)
+        # command is always safe to expose
+        assert span.attrs.get("gen_ai.client.command") == "ls"
+        # content should NOT be flattened by default
+        assert "gen_ai.client.tool.input.command" not in span.attrs
+        assert "gen_ai.client.tool.response.output" not in span.attrs
+        # length + digest should be present
+        assert "gen_ai.client.tool.input.length" in span.attrs
+        assert "gen_ai.client.tool.input.sha256" in span.attrs
+        assert "gen_ai.client.tool.response.length" in span.attrs
+        assert "gen_ai.client.tool.response.sha256" in span.attrs
+
+    def test_opt_in_flattens_content(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "1")
+        span = _FakeSpan()
+        data = {"tool_input": {"command": "ls", "path": "/tmp"}, "tool_response": {"output": "file.txt"}}
+        otel_hook._set_codex_tool_attrs(span, "PreToolUse", data)
+        assert span.attrs.get("gen_ai.client.tool.input.command") == "ls"
+        assert span.attrs.get("gen_ai.client.tool.response.output") == "file.txt"
+
+    def test_permission_request_handled(self, monkeypatch):
+        monkeypatch.delenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", raising=False)
+        span = _FakeSpan()
+        data = {"tool_input": {"description": "need access"}}
+        otel_hook._set_codex_tool_attrs(span, "PermissionRequest", data)
+        assert span.attrs.get("gen_ai.client.approval.description") == "need access"
+
+    def test_permission_request_in_tool_events(self):
+        assert "PermissionRequest" in otel_hook._TOOL_EVENTS
+
 
 # ── New IDE name aliases ─────────────────────────────────────────────────
 

--- a/tests/test_setup_sh.py
+++ b/tests/test_setup_sh.py
@@ -147,6 +147,12 @@ def _gemini_settings_doc(tmp_root: str) -> dict:
         return json.load(f)
 
 
+def _codex_hooks_doc(tmp_root: str) -> dict:
+    hooks_json = os.path.join(tmp_root, ".codex", "hooks.json")
+    with open(hooks_json) as f:
+        return json.load(f)
+
+
 def _copilot_hooks_doc(tmp_root: str) -> dict:
     hooks_json = os.path.join(tmp_root, ".github", "hooks", "otel-hooks.json")
     with open(hooks_json) as f:
@@ -726,6 +732,39 @@ class TestGeminiSetup:
                         f"OTel hook was not removed for event {event!r}: {cmd!r}"
                     )
 
+    def test_codex_global_creates_hooks_and_config(self, tmp_path):
+        """setup.sh --codex --global must create ~/.codex/hooks.json and enable codex_hooks."""
+        hook_dir = _make_hook_dir(str(tmp_path))
+        env = self._minimal_env(tmp_path)
+
+        result = _run_setup(hook_dir, args=["--codex", "--global"], env=env)
+        assert result.returncode == 0, result.stderr
+
+        hooks_path = tmp_path / ".codex" / "hooks.json"
+        config_path = tmp_path / ".codex" / "config.toml"
+        assert hooks_path.exists()
+        assert config_path.exists()
+        assert "codex_hooks = true" in config_path.read_text()
+
+        doc = _codex_hooks_doc(str(tmp_path))
+        assert "PermissionRequest" in doc["hooks"]
+        assert doc["hooks"]["SessionStart"][0]["matcher"] == "startup|resume|clear"
+        assert doc["hooks"]["PreToolUse"][0]["matcher"] == "*"
+        assert "matcher" not in doc["hooks"]["UserPromptSubmit"][0]
+
+    def test_codex_uninstall_removes_all_otel_hooks(self, tmp_path):
+        """--uninstall --codex must remove all OTel hook entries."""
+        hook_dir = _make_hook_dir(str(tmp_path))
+        env = self._minimal_env(tmp_path)
+
+        result = _run_setup(hook_dir, args=["--codex", "--global"], env=env)
+        assert result.returncode == 0, result.stderr
+
+        result = _run_setup(hook_dir, args=["--uninstall", "--codex", "--global"], env=env)
+        assert result.returncode == 0, result.stderr
+        doc = _codex_hooks_doc(str(tmp_path))
+        assert doc.get("hooks", {}) == {}
+
     def test_diagnose_auto_detects_gemini_when_dir_exists(self, tmp_path):
         """--diagnose without an IDE flag must auto-detect gemini when ~/.gemini exists."""
         hook_dir = _make_hook_dir(str(tmp_path))
@@ -859,4 +898,3 @@ class TestOperationalFlags:
             for h in entries:
                 cmd = h.get("command", "")
                 assert "otel_hook" not in cmd and "otel-hook" not in cmd
-


### PR DESCRIPTION
## Summary

Adds Codex as a first-class hook target for opentelemetry-hooks.

## Changes

- Adds Codex runtime detection, event normalization, `PermissionRequest`, and Codex tool payload attributes.
- Adds `otel-hook setup|diagnose|uninstall --agent codex` and `setup.sh --codex` support.
- Adds a Codex hooks example and README coverage, including the native Codex OTel double-export warning.
- Adds CLI, runtime, and setup.sh regression tests for Codex.

## Validation

- `env PYTHONPYCACHEPREFIX=/private/tmp/otel-hooks-pycache python3 -m py_compile otel_hook.py`
- `bash -n setup.sh`
- `tmpdir=$(mktemp -d /private/tmp/otel-py312-path-XXXXXX) && mkdir -p "$tmpdir/bin" && ln -s /opt/homebrew/bin/python3.12 "$tmpdir/bin/python3" && env PATH="$tmpdir/bin:/usr/bin:/bin:/usr/sbin:/sbin" /usr/bin/python3 -m pytest`
- `pipx reinstall opentelemetry-hooks`
- `which otel-hook`
- `otel-hook --version 2>/dev/null || echo "no version flag — binary is live"`