### PR TITLE
[codex] improve README and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: ["**"]
-    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -63,7 +62,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: python -m pip install --upgrade pip build setuptools-scm
+        run: python -m pip install --upgrade pip build
 
       - name: Build package
         run: python -m build
@@ -73,21 +72,3 @@ jobs:
         with:
           name: dist
           path: dist/
-
-  release:
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,33 +59,28 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: python -m pip install build setuptools-scm python-semantic-release
+        run: python -m pip install build twine python-semantic-release
 
       - name: Determine version
         id: semver
         run: |
+          ARGS=()
           if [ -n "${{ inputs.version }}" ]; then
-            VERSION="${{ inputs.version }}"
-            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::Version must be in semver format (e.g. 0.2.0), got: $VERSION"
-              exit 1
-            fi
-            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "Manually specified version: $VERSION"
+            ARGS+=(--version "${{ inputs.version }}")
+          fi
+          if [ -n "${{ inputs.force }}" ]; then
+            ARGS+=(--force "${{ inputs.force }}")
+          fi
+          if [ "${#ARGS[@]}" -gt 0 ]; then
+            VERSION=$(python3 scripts/release_workflow.py determine-version "${ARGS[@]}")
           else
-            FORCE_ARG=""
-            if [ -n "${{ inputs.force }}" ]; then
-              FORCE_ARG="--${{ inputs.force }}"
-            fi
-            SEMREL_OUTPUT=$(semantic-release version --print $FORCE_ARG 2>&1) || true
-            VERSION=$(echo "$SEMREL_OUTPUT" | tail -1 | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' || true)
-            if [ -z "$VERSION" ]; then
-              echo "::notice::No version bump detected from commits. Use 'force' or provide an explicit 'version'."
-              echo "::notice::semantic-release output: $SEMREL_OUTPUT"
-            else
-              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-              echo "Auto-detected version: $VERSION"
-            fi
+            VERSION=$(python3 scripts/release_workflow.py determine-version)
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::notice::No unreleased version found in pyproject.toml and no semantic-release bump was detected."
+          else
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "Resolved release version: $VERSION"
           fi
 
       - name: Check tag does not already exist
@@ -96,19 +91,24 @@ jobs:
             exit 1
           fi
 
-      - name: Update version in README
+      - name: Bump version in pyproject.toml, README.md, and CHANGELOG.md
         if: steps.semver.outputs.version != ''
         run: |
+          python scripts/bump_version.py "${{ steps.semver.outputs.version }}"
           python scripts/update_readme_release_refs.py README.md "${{ steps.semver.outputs.version }}"
-          if git diff --quiet README.md; then
-            echo "README already up to date"
+          if git diff --quiet; then
+            echo "Files already up to date"
           else
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "docs: update install version to v${{ steps.semver.outputs.version }}"
+            git add pyproject.toml README.md CHANGELOG.md
+            git commit -m "release: v${{ steps.semver.outputs.version }}"
             git push origin HEAD
           fi
+
+      - name: Build release notes
+        if: steps.semver.outputs.version != ''
+        run: python3 scripts/release_workflow.py release-notes "${{ steps.semver.outputs.version }}" > release-notes.md
 
       - name: Create and push tag
         if: steps.semver.outputs.version != ''
@@ -120,15 +120,11 @@ jobs:
 
       - name: Build package
         if: steps.semver.outputs.version != ''
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ steps.semver.outputs.version }}
         run: python -m build
 
       - name: Verify package
         if: steps.semver.outputs.version != ''
-        run: |
-          pip install twine
-          twine check dist/*
+        run: twine check dist/*
 
       - name: Create GitHub Release
         if: steps.semver.outputs.version != ''
@@ -136,7 +132,7 @@ jobs:
         with:
           tag_name: v${{ steps.semver.outputs.version }}
           files: dist/*
-          generate_release_notes: true
+          body_path: release-notes.md
 
       - name: Delete merged branches
         if: steps.semver.outputs.version != ''
@@ -172,11 +168,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: pip install build setuptools-scm
+        run: pip install build
 
       - name: Build package
-        env:
-          SETUPTOOLS_SCM_PRETEND_VERSION: ${{ needs.release.outputs.version }}
         run: python -m build
 
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Check tag does not already exist
         if: steps.semver.outputs.version != ''
         run: |
-          if git rev-parse "v${{ steps.semver.outputs.version }}" >/dev/null 2>&1; then
+          if git show-ref --tags --verify --quiet "refs/tags/v${{ steps.semver.outputs.version }}"; then
             echo "::error::Tag v${{ steps.semver.outputs.version }} already exists"
             exit 1
           fi

--- a/.github/workflows/weekly-agentic.yml
+++ b/.github/workflows/weekly-agentic.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt build setuptools-scm
+        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt build
 
       - name: Run tests
         id: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 0.13.0 (unreleased)
+
+### Added
+- Added a supported-agent setup matrix to the README covering Cursor, Claude Code, Gemini CLI, GitHub Copilot, OpenCode, and compatible hook runners
+- Added dedicated Gemini CLI setup documentation and clarified how Gemini model, tool, and agent lifecycle events map to canonical hook spans
+- Added this changelog and release workflow helpers so GitHub releases use curated release notes from `CHANGELOG.md`
+
+### Changed
+- Switched release versioning from tag-derived `setuptools-scm` metadata to a checked-in `pyproject.toml` version managed by the release workflow
+- Refreshed pip/pipx, source-checkout, config, and log path docs so package installs and copied-source installs are easier to distinguish
+- Updated the pinned README install example and package metadata for the `0.13.0` release
+
+### Fixed
+- Included the OpenCode TypeScript example in package data and source distributions so documented examples are present in built artifacts
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include CHANGELOG.md
 recursive-include examples *.json
 recursive-include examples *.md
 recursive-include examples *.ts
+recursive-include scripts *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include examples *.json
 recursive-include examples *.md
+recursive-include examples *.ts

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ IDE Event → stdin (JSON) → otel-hook → OpenTelemetry SDK → OTLP Backend
 
 ## Features
 
-- **Multi-IDE Support**: One script, multiple hook providers — `setup.sh` now creates native hook configs for Cursor, GitHub Copilot, and Claude Code without extra IDE override env vars, while the bundled examples cover Copilot/Claude/Cursor for manual installs. The runtime prefers parent-process discovery first, then explicit overrides, then self-reported payload fields, and finally heuristics when needed.
+- **Multi-agent support**: One hook command, multiple agent integrations. The CLI and `setup.sh` can register Cursor, Claude Code, Gemini CLI, GitHub Copilot, and OpenCode. Antigravity and compatible hook runners can call the same hook command directly. Runtime detection prefers parent-process discovery first, then explicit overrides, then self-reported payload fields, and finally heuristics when needed.
 
 - **Session-level Traces**: Groups all events within a session into a single trace with a 3-tier hierarchy:
 
@@ -55,6 +55,19 @@ gen_ai.client.session (root)
 - **Privacy Controls**: Built-in masking of emails, tokens, and usernames. Text capture is opt-in.
 
 - **JSON Config File**: All settings in `otel_config.json` — no environment variable exports needed.
+
+## Supported Agents
+
+| Agent | Setup Command | Scope | Config Written |
+|---|---|---|---|
+| Cursor IDE / CLI | `otel-hook setup --agent cursor` | Global by default; use `--no-global` for project scope | `~/.cursor/hooks.json` or `.cursor/hooks.json` |
+| Claude Code | `otel-hook setup --agent claude` | Global by default; use `--no-global` for project scope | `~/.claude/settings.json` or `.claude/settings.json` |
+| Gemini CLI | `otel-hook setup --agent gemini` | Global by default; use `--no-global` for project scope | `~/.gemini/settings.json` or `.gemini/settings.json` |
+| GitHub Copilot coding agent | `otel-hook setup --agent copilot --no-global` | Repository only | `.github/hooks/otel-hooks.json` |
+| OpenCode | `otel-hook setup --agent opencode` | Global by default; use `--no-global` for project scope | `~/.config/opencode/plugins/otel-hook.ts` or `.opencode/plugins/otel-hook.ts` |
+| Antigravity / compatible runners | Manual hook command | Runner-defined | Runner workflow/config |
+
+Run `otel-hook diagnose` to see what is currently registered, and `otel-hook uninstall --agent <agent>` to remove this hook from an agent config.
 
 ## Supported Events
 
@@ -94,7 +107,7 @@ pip install opentelemetry-hooks
 To pin a specific version or install directly from a tag:
 
 ```bash
-pipx install git+https://github.com/o11y-dev/opentelemetry-hooks.git@v0.12.0
+pipx install git+https://github.com/o11y-dev/opentelemetry-hooks.git@v0.13.0
 ```
 
 Or install from a pre-built wheel from the [Releases](https://github.com/o11y-dev/opentelemetry-hooks/releases) page:
@@ -120,6 +133,7 @@ otel-hook setup --agent claude
 otel-hook setup --agent cursor
 otel-hook setup --agent copilot --no-global   # project-scoped (run from repo root)
 otel-hook setup --agent gemini
+otel-hook setup --agent opencode
 
 # Project-scoped instead of global
 otel-hook setup --agent cursor --no-global
@@ -142,30 +156,34 @@ vim ~/.local/share/opentelemetry-hooks/otel_config.json
 The setup functions are importable for programmatic use:
 
 ```python
-from otel_hook import setup_agent, setup_claude, setup_cursor
+from otel_hook import setup_agent, setup_claude, setup_cursor, setup_gemini
 
 setup_claude(global_=True)   # ~/.claude/settings.json
 setup_cursor(global_=True)   # ~/.cursor/hooks.json
 setup_agent("gemini", global_=True)
 ```
 
-### Source Checkout / Cursor Project Setup
+### Source Checkout Setup
 
 If you're working from a source checkout rather than a pip install, use the
 bundled `setup.sh`:
 
 ```bash
-# Project-level — hooks.json in the current repo (.cursor/hooks.json)
-bash .cursor/hooks/opentelemetry-hook/setup.sh
+# Auto-detect installed/supported agents and configure them
+bash setup.sh
 
-# Global — applies to every Cursor project (~/.cursor/hooks.json)
-bash .cursor/hooks/opentelemetry-hook/setup.sh --cursor --global
+# Configure one agent
+bash setup.sh --cursor --global
+bash setup.sh --claude --global
+bash setup.sh --gemini --global
+bash setup.sh --copilot       # repository-scoped
+bash setup.sh --opencode --global
 ```
 
-Then edit your endpoint config and restart Cursor:
+Then edit your endpoint config and restart the configured agent:
 
 ```bash
-vim .cursor/hooks/opentelemetry-hook/otel_config.json
+vim otel_config.json
 ```
 
 ### Clone Into an Existing Project
@@ -202,7 +220,7 @@ Cursor CLI uses the same `.cursor/hooks.json` configuration and hook payload sha
 
 ```bash
 # Repo-scoped hooks file (.github/hooks/otel-hooks.json)
-bash .cursor/hooks/opentelemetry-hook/setup.sh --copilot
+bash setup.sh --copilot
 ```
 
 `setup.sh --copilot` creates or merges `.github/hooks/otel-hooks.json` and points each event directly at `otel-hook` (or the local `otel_hook.py` fallback). Copilot is then detected from the process tree first, with `session_id`-based heuristics as a fallback.
@@ -213,7 +231,7 @@ If you prefer a manual install, copy the bundled example instead:
 
 ```bash
 mkdir -p .github/hooks
-cp .cursor/hooks/opentelemetry-hook/examples/copilot-hooks.example.json .github/hooks/otel-hooks.json
+cp examples/copilot-hooks.example.json .github/hooks/otel-hooks.json
 ```
 
 Then replace `{{SCRIPT_PATH}}` with the hook command. For a copied-source checkout the default is `python3 .cursor/hooks/opentelemetry-hook/otel_hook.py`; use `otel-hook` only when the package is installed via pipx or pip.
@@ -223,7 +241,7 @@ See [GitHub Copilot hooks docs](https://docs.github.com/en/copilot/concepts/agen
 
 ```bash
 mkdir -p .claude
-cp .cursor/hooks/opentelemetry-hook/examples/claude-hooks.example.json .claude/settings.json
+cp examples/claude-hooks.example.json .claude/settings.json
 ```
 
 Replace `{{SCRIPT_PATH}}` with the hook command, for example:
@@ -237,6 +255,24 @@ otel-hook
 
 The bundled Claude example and `setup.sh --claude` both invoke `otel-hook` directly without an IDE override env var.
 Claude Code is auto-detected from the parent process tree first; hook metadata such as `session_id`, `transcript_path`, `permission_mode`, and `notification_type` is used as a fallback. The camelCase alias handling is mainly for compatible third-party hook runners and mixed payload formats.
+
+#### Gemini CLI
+
+```bash
+# Global Gemini settings (~/.gemini/settings.json)
+otel-hook setup --agent gemini
+
+# Project-scoped Gemini settings (.gemini/settings.json)
+otel-hook setup --agent gemini --no-global
+```
+
+For a source checkout, use:
+
+```bash
+bash setup.sh --gemini --global
+```
+
+Gemini CLI emits model, tool, and agent lifecycle events. The hook maps `BeforeModel` / `AfterModel` to prompt and stop spans, `BeforeTool` / `AfterTool` to tool spans, and `BeforeAgent` / `AfterAgent` to subagent spans.
 
 #### Antigravity
 
@@ -302,7 +338,7 @@ To make this hook automatically available to the GitHub Copilot coding agent acr
 
 ### Configuration
 
-Edit `.cursor/hooks/opentelemetry-hook/otel_config.json`:
+Edit the hook config file. For pip/pipx installs this lives at `~/.local/share/opentelemetry-hooks/otel_config.json` unless `IDE_OTEL_HOOK_HOME` is set. For a source checkout or copied-source install, edit the local `otel_config.json` next to `otel_hook.py`.
 
 ```json
 {
@@ -313,7 +349,7 @@ Edit `.cursor/hooks/opentelemetry-hook/otel_config.json`:
 }
 ```
 
-Then restart your IDE.
+Then restart your agent or IDE.
 
 ## Configuration Reference
 
@@ -333,7 +369,7 @@ Then restart your IDE.
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `IDE_OTEL_BATCH_ON_STOP` | Enable session-level batching (recommended) | `false` |
-| `IDE_OTEL_IDE_NAME` | Force the detected IDE name (`cursor`, `copilot`, `claude`, `antigravity`, `opencode`) for generic hook runners; common labels like `GitHub Copilot`, `Claude Code`, `Cursor IDE` / `Cursor CLI`, `Anti Gravity`, `OpenCode`, and their `... CLI` / `... IDE` variants normalize automatically | auto-detect |
+| `IDE_OTEL_IDE_NAME` | Force the detected IDE name (`cursor`, `copilot`, `claude`, `gemini`, `antigravity`, `opencode`) for generic hook runners; common labels like `GitHub Copilot`, `Claude Code`, `Cursor IDE` / `Cursor CLI`, `Gemini CLI`, `Anti Gravity`, `OpenCode`, and their `... CLI` / `... IDE` variants normalize automatically | auto-detect |
 | `IDE_OTEL_LOCAL_SPANS` | Save hook spans locally as JSONL files for agent analysis (`.state/local_spans/*.jsonl`) | unset |
 | `IDE_OTEL_CAPTURE_TEXT` | Include prompt/response text in spans | `false` |
 | `IDE_OTEL_MASK_PROMPTS` | Redact emails, tokens, usernames from text | `false` |
@@ -727,6 +763,7 @@ The detected outer IDE is recorded on spans as `gen_ai.client.name` and is also 
         │   ├── cursor-hooks.example.json       # Minimal Cursor hooks template
         │   ├── copilot-hooks.example.json      # GitHub Copilot hooks template
         │   ├── claude-hooks.example.json       # Claude Code hooks template
+        │   ├── opencode-plugin.example.ts      # OpenCode plugin template
         │   └── antigravity-workflow.example.md # Antigravity workflow template
         ├── .gitignore                          # Excludes secrets, venv, state
         ├── .venv/                              # Python venv (auto-provisioned)
@@ -762,7 +799,11 @@ Set `IDE_OTEL_CAPTURE_TEXT=true` to include prompt/response text. Combine with `
 ### Check the log
 
 ```bash
-tail -f .cursor/hooks/opentelemetry-hook/otel_hook.log
+# pip/pipx install
+tail -f ~/.local/share/opentelemetry-hooks/otel_hook.log
+
+# source checkout / copied-source install
+tail -f ./otel_hook.log
 ```
 
 ### Enable debug output

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ otel-hook setup --agent claude
 otel-hook setup --agent cursor
 otel-hook setup --agent copilot --no-global   # project-scoped (run from repo root)
 otel-hook setup --agent gemini
-otel-hook setup --agent opencode
 otel-hook setup --agent codex
+otel-hook setup --agent opencode
 
 # Project-scoped instead of global
 otel-hook setup --agent cursor --no-global
@@ -159,11 +159,11 @@ vim ~/.local/share/opentelemetry-hooks/otel_config.json
 The setup functions are importable for programmatic use:
 
 ```python
-from otel_hook import setup_agent, setup_claude, setup_cursor, setup_gemini
+from otel_hook import setup_claude, setup_cursor, setup_gemini
 
 setup_claude(global_=True)   # ~/.claude/settings.json
 setup_cursor(global_=True)   # ~/.cursor/hooks.json
-setup_agent("gemini", global_=True)
+setup_gemini(global_=True)   # ~/.gemini/settings.json
 ```
 
 ### Source Checkout Setup
@@ -757,12 +757,14 @@ Example: `https://ingress.us1.coralogix.com:443/v1/traces` → `https://ingress.
 
 When `IDE_OTEL_BATCH_ON_STOP=true` (recommended):
 
-1. **SessionStart**: Pre-generates a `trace_id` shared by all spans in the session. Stored in `.state/sessions/`.
+1. **SessionStart**: If the hook receives upstream trace context (`traceparent` / `TRACEPARENT`, or explicit `trace_id` + `span_id` / `parent_span_id`), it adopts that real `trace_id` and parent span for the session. Otherwise it pre-generates a synthetic `trace_id`. State is stored in `.state/sessions/`.
 2. **Generation events**: Buffered to `.state/batches/<generation_id>.jsonl`.
 3. **Stop**: Flushes the generation's events as a `gen_ai.client.generation` span with child event spans. All share the session's `trace_id`. Exported immediately to avoid data loss.
 4. **SessionEnd**: Emits the root `gen_ai.client.session` span covering the full session duration. Cleans up state files.
 
 For IDEs without a `generation_id` (Copilot), the hook auto-derives generation boundaries from `UserPromptSubmit` → `Stop` cycles using an internal counter.
+
+When upstream context is present, hook spans keep the real `trace_id` and attach to the real upstream parent span. The hook still cannot force a specific emitted `span_id` for its own spans because the Python OpenTelemetry SDK assigns span IDs when spans are started.
 
 ## IDE Detection
 
@@ -780,7 +782,7 @@ The hook auto-detects which IDE is calling it:
 
 Detection order is: (1) parent process tree, (2) explicit `IDE_OTEL_IDE_NAME`, (3) self-reported payload fields, then (4) heuristics. `setup.sh` now relies on process discovery for generated Cursor, Copilot, and Claude configs, while the env var remains available as an escape hatch for generic runners and debugging.
 
-The detected outer IDE is recorded on spans as `gen_ai.client.name` and is also exported as the `gen_ai.system` resource attribute via `OTEL_RESOURCE_ATTRIBUTES` for backward compatibility. When nested signals indicate a different inner engine (for example Cursor hosting Claude Code), the hook additionally records `gen_ai.client.agent_engine`. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
+The hook still detects the outer wrapper IDE/process, but the emitted canonical client identity now prefers a distinct inner engine when one is present (for example Gemini running under Claude Code). In that case, spans/resources use the inner engine for `gen_ai.client.name` and `gen_ai.system`, keep `gen_ai.client.agent_engine` for compatibility, and record the wrapper as `gen_ai.client.wrapper`. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
 
 ## File Structure
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -262,6 +262,9 @@ _MDM_REGISTRY_PATH = r"SOFTWARE\Policies\OpenTelemetryHook"  # Windows registry 
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 _TOKEN_RE = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
 _HOME_RE = re.compile(r"/Users/[^/\s]+")
+_HEX_DIGITS = frozenset("0123456789abcdef")
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +395,11 @@ _INPUT_ALIASES = {
     "appVersion": "app_version",
     "ideName": "ide_name",
     "sourceApp": "source_app",
+    "traceId": "trace_id",
+    "spanId": "span_id",
+    "parentSpanId": "parent_span_id",
+    "traceFlags": "trace_flags",
+    "traceState": "tracestate",
 }
 
 # Canonical gen_ai.client.name values accepted directly from IDE_OTEL_IDE_NAME or
@@ -519,6 +527,14 @@ def _first_present(data: dict, keys: tuple):
     for key in keys:
         if key in data and data[key] is not None:
             return data[key]
+    return None
+
+
+def _first_env(keys: tuple[str, ...]) -> Optional[str]:
+    for key in keys:
+        value = os.getenv(key)
+        if value:
+            return value
     return None
 
 
@@ -663,7 +679,15 @@ def _detect_client_version(data: dict, ide: str) -> Optional[str]:
 
 def _detect_agent_engine(data: dict) -> Optional[str]:
     """Detect an inner agent engine without consulting IDE_OTEL_IDE_NAME."""
-    explicit = _normalize_ide_name(_first_present(data, ("agent_engine", "agentEngine", "engine", "engine_name")))
+    explicit = _normalize_ide_name(_first_present(
+        data,
+        (
+            "agent_engine",
+            "agentEngine",
+            "engine",
+            "engine_name",
+        ),
+    ))
     if explicit:
         return explicit
 
@@ -680,6 +704,19 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     if reported:
         return reported
 
+    semantic_signals = [
+        _normalize_ide_name(_first_present(data, ("gen_ai.client.name",))),
+        _normalize_ide_name(_first_present(data, ("gen_ai.system",))),
+        _normalize_ide_name(_first_present(data, ("service.name", "service_name"))),
+    ]
+    semantic_counts: dict[str, int] = {}
+    for signal in semantic_signals:
+        if signal:
+            semantic_counts[signal] = semantic_counts.get(signal, 0) + 1
+    corroborated = [name for name, count in semantic_counts.items() if count >= 2]
+    if len(corroborated) == 1:
+        return corroborated[0]
+
     raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
     if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
         return "claude"
@@ -687,17 +724,40 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     return None
 
 
+def _resolved_agent_engine(data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> Optional[str]:
+    resolved = _detect_agent_engine(data or {})
+    if resolved:
+        return resolved
+    if session_ctx:
+        return _normalize_ide_name(session_ctx.get("agent_engine"))
+    return None
+
+
+def _resolve_client_name(
+    ide: str,
+    data: Optional[dict] = None,
+    agent_engine: Optional[str] = None,
+    session_ctx: Optional[dict] = None,
+) -> str:
+    resolved_engine = agent_engine if agent_engine is not None else _resolved_agent_engine(data, session_ctx)
+    if resolved_engine and resolved_engine != ide:
+        return resolved_engine
+    return ide
+
+
 def _set_client_identity_attributes(
-    span, ide: str, data: Optional[dict] = None, agent_engine: Optional[str] = None,
+    span, ide: str, data: Optional[dict] = None, agent_engine: Optional[str] = None, session_ctx: Optional[dict] = None,
 ) -> Optional[str]:
-    """Attach outer IDE identity and, when distinct, the inner agent engine.
+    """Attach canonical client identity and preserve wrapper identity when nested.
 
     Returns the resolved inner engine when one is detected and differs from the
     outer IDE; otherwise returns ``None``.
     """
-    span.set_attribute("gen_ai.client.name", ide)
-    resolved_engine = agent_engine if agent_engine is not None else _detect_agent_engine(data or {})
+    resolved_engine = agent_engine if agent_engine is not None else _resolved_agent_engine(data, session_ctx)
+    client_name = _resolve_client_name(ide, data=data, agent_engine=resolved_engine, session_ctx=session_ctx)
+    span.set_attribute("gen_ai.client.name", client_name)
     if resolved_engine and resolved_engine != ide:
+        span.set_attribute("gen_ai.client.wrapper", ide)
         span.set_attribute("gen_ai.client.agent_engine", resolved_engine)
         return resolved_engine
     return None
@@ -1465,7 +1525,7 @@ def _force_flush_provider(timeout_millis: int = 500) -> None:
         _LOGGER.warning("log force_flush failed: %s", exc)
 
 
-def _init_tracing(ide: str = "cursor") -> bool:
+def _init_tracing(ide: str = "cursor", client_name: Optional[str] = None) -> bool:
     global _TRACING_INITIALIZED
     if _TRACING_INITIALIZED:
         return True
@@ -1478,9 +1538,13 @@ def _init_tracing(ide: str = "cursor") -> bool:
         os.environ["OTEL_SERVICE_NAME"] = service_name
 
     app_name = os.getenv("IDE_OTEL_APP_NAME") or os.getenv("OTEL_SERVICE_NAME") or "ide-agent"
+    resolved_client_name = client_name or ide
     resource_attrs = _parse_resource_attributes(os.getenv("OTEL_RESOURCE_ATTRIBUTES", ""))
     resource_attrs.setdefault("service.name", app_name)
-    resource_attrs.setdefault("gen_ai.system", ide)
+    resource_attrs.setdefault("gen_ai.client.name", resolved_client_name)
+    resource_attrs.setdefault("gen_ai.system", resolved_client_name)
+    if ide != resolved_client_name:
+        resource_attrs.setdefault("gen_ai.client.wrapper", ide)
 
     # OS / host resource attributes (OTel semantic conventions)
     os_info = _get_os_info()
@@ -1947,16 +2011,25 @@ def _session_path(session_key: str) -> str:
 
 
 def _create_session_context(session_key: str, data: dict, ide: str) -> dict:
-    """Create and persist a new session context with pre-generated trace IDs."""
+    """Create and persist a new session context with upstream or synthetic trace IDs."""
     os.makedirs(_SESSION_DIR, exist_ok=True)
+    upstream_ctx = _resolve_upstream_trace_context(data)
     ctx = {
-        "trace_id": f"{random.getrandbits(128):032x}",
         "phantom_parent_id": f"{random.getrandbits(64):016x}",
+        "trace_id": f"{random.getrandbits(128):032x}",
         "start_time_ns": time.time_ns(),
         "ide": ide,
         "generation_count": 0,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "context_origin": "synthetic",
     }
+    if upstream_ctx is not None:
+        ctx["trace_id"] = upstream_ctx["trace_id"]
+        ctx["upstream_parent_span_id"] = upstream_ctx["parent_span_id"]
+        ctx["trace_flags"] = upstream_ctx.get("trace_flags", "01")
+        if upstream_ctx.get("tracestate"):
+            ctx["tracestate"] = upstream_ctx["tracestate"]
+        ctx["context_origin"] = "upstream"
     if model := _first_present(data, ("request_model", "model", "model_name")):
         ctx["last_known_model"] = model
 
@@ -1987,6 +2060,24 @@ def _write_session_context(session_key: str, ctx: dict) -> None:
     lock_path = os.path.join(_LOCK_DIR, f"{re.sub(r'[^A-Za-z0-9_.-]+', '_', session_key)}.lock")
     with _acquire_lock(lock_path):
         _atomic_write_json(_session_path(session_key), ctx)
+
+
+def _maybe_bind_session_to_upstream_context(session_key: Optional[str], session_ctx: Optional[dict], data: dict) -> Optional[dict]:
+    if not session_key or not session_ctx or session_ctx.get("context_origin") == "upstream":
+        return session_ctx
+    upstream_ctx = _resolve_upstream_trace_context(data)
+    if upstream_ctx is None:
+        return session_ctx
+    session_ctx["trace_id"] = upstream_ctx["trace_id"]
+    session_ctx["upstream_parent_span_id"] = upstream_ctx["parent_span_id"]
+    session_ctx["trace_flags"] = upstream_ctx.get("trace_flags", "01")
+    if upstream_ctx.get("tracestate"):
+        session_ctx["tracestate"] = upstream_ctx["tracestate"]
+    else:
+        session_ctx.pop("tracestate", None)
+    session_ctx["context_origin"] = "upstream"
+    _write_session_context(session_key, session_ctx)
+    return session_ctx
 
 
 def _clear_session_context(session_key: Optional[str]) -> None:
@@ -2137,7 +2228,85 @@ def _clear_batch_events(key: str) -> None:
 # ---------------------------------------------------------------------------
 # Trace context helpers
 # ---------------------------------------------------------------------------
-def _make_trace_context(trace_id_hex: str, span_id_hex: str):
+def _parse_traceparent(value: Optional[str]) -> Optional[dict]:
+    if not isinstance(value, str):
+        return None
+    parts = value.strip().lower().split("-")
+    if len(parts) < 4:
+        return None
+    version, trace_id, span_id, trace_flags = parts[:4]
+    if version == "ff":
+        return None
+    if len(version) != 2 or len(trace_flags) != 2:
+        return None
+    if version == "00" and len(parts) != 4:
+        return None
+    if version != "00" and len(parts) > 4 and any(part == "" for part in parts[4:]):
+        return None
+    if any(ch not in _HEX_DIGITS for ch in version) or any(ch not in _HEX_DIGITS for ch in trace_flags):
+        return None
+    if not _TRACE_ID_RE.match(trace_id) or not _SPAN_ID_RE.match(span_id):
+        return None
+    if trace_id == "0" * 32 or span_id == "0" * 16:
+        return None
+    return {
+        "trace_id": trace_id,
+        "parent_span_id": span_id,
+        "trace_flags": trace_flags,
+    }
+
+
+def _resolve_upstream_trace_context(data: Optional[dict]) -> Optional[dict]:
+    data = data or {}
+    tracestate = _first_present(data, ("tracestate",)) or _first_env(
+        ("IDE_OTEL_TRACESTATE", "TRACESTATE", "OTEL_TRACESTATE")
+    )
+    traceparent = _first_present(data, ("traceparent",)) or _first_env(
+        ("IDE_OTEL_TRACEPARENT", "TRACEPARENT", "OTEL_TRACEPARENT")
+    )
+    parsed = _parse_traceparent(traceparent)
+    if parsed is not None:
+        if isinstance(tracestate, str) and tracestate.strip():
+            parsed["tracestate"] = tracestate.strip()
+        return parsed
+
+    trace_id = _lower_or_none(_first_present(data, ("trace_id",)) or _first_env(
+        ("IDE_OTEL_TRACE_ID", "TRACE_ID", "OTEL_TRACE_ID")
+    ))
+    span_id = _lower_or_none(_first_present(data, ("span_id",)) or _first_env(
+        ("IDE_OTEL_SPAN_ID", "SPAN_ID", "OTEL_SPAN_ID")
+    ))
+    parent_span_id = _lower_or_none(_first_present(data, ("parent_span_id",)) or _first_env(
+        ("IDE_OTEL_PARENT_SPAN_ID", "PARENT_SPAN_ID", "OTEL_PARENT_SPAN_ID")
+    ))
+    trace_flags = _lower_or_none(_first_present(data, ("trace_flags",)) or _first_env(
+        ("IDE_OTEL_TRACE_FLAGS", "TRACE_FLAGS", "OTEL_TRACE_FLAGS")
+    )) or "01"
+    effective_parent_span_id = span_id or parent_span_id
+    if trace_id is None or effective_parent_span_id is None:
+        return None
+    if not _TRACE_ID_RE.match(trace_id) or trace_id == "0" * 32:
+        return None
+    if not _SPAN_ID_RE.match(effective_parent_span_id) or effective_parent_span_id == "0" * 16:
+        return None
+    if not re.fullmatch(r"[0-9a-f]{2}", trace_flags):
+        trace_flags = "01"
+    ctx = {
+        "trace_id": trace_id,
+        "parent_span_id": effective_parent_span_id,
+        "trace_flags": trace_flags,
+    }
+    if isinstance(tracestate, str) and tracestate.strip():
+        ctx["tracestate"] = tracestate.strip()
+    return ctx
+
+
+def _make_trace_context(
+    trace_id_hex: str,
+    span_id_hex: str,
+    trace_flags_hex: str = "01",
+    tracestate_header: Optional[str] = None,
+):
     """Create an OTel context from hex trace/span IDs for cross-process linking."""
     if SpanContext is None:
         return None
@@ -2148,11 +2317,47 @@ def _make_trace_context(trace_id_hex: str, span_id_hex: str):
         return None
     if not tid or not sid:
         return None
+    trace_flags = TraceFlags(TraceFlags.SAMPLED)
+    try:
+        trace_flags = TraceFlags(int(trace_flags_hex, 16) & 0xFF)
+    except (ValueError, TypeError):
+        pass
+    trace_state = TraceState()
+    if tracestate_header and hasattr(TraceState, "from_header"):
+        try:
+            parsed_state = TraceState.from_header([tracestate_header])
+            if parsed_state is not None:
+                trace_state = parsed_state
+        except Exception:
+            pass
     ctx = SpanContext(
         trace_id=tid, span_id=sid, is_remote=True,
-        trace_flags=TraceFlags(TraceFlags.SAMPLED), trace_state=TraceState(),
+        trace_flags=trace_flags, trace_state=trace_state,
     )
     return trace.set_span_in_context(NonRecordingSpan(ctx))
+
+
+def _session_trace_context(session_ctx: Optional[dict]):
+    if not session_ctx:
+        return None
+    return _make_trace_context(
+        session_ctx.get("trace_id", "0"),
+        session_ctx.get("upstream_parent_span_id") or session_ctx.get("phantom_parent_id", "0"),
+        session_ctx.get("trace_flags", "01"),
+        session_ctx.get("tracestate"),
+    )
+
+
+def _event_parent_trace_context(data: dict, session_ctx: Optional[dict]):
+    upstream_ctx = _resolve_upstream_trace_context(data)
+    if upstream_ctx is not None:
+        return _make_trace_context(
+            upstream_ctx["trace_id"],
+            upstream_ctx["parent_span_id"],
+            upstream_ctx.get("trace_flags", "01"),
+            upstream_ctx.get("tracestate"),
+        )
+    return _session_trace_context(session_ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -2182,8 +2387,7 @@ def _apply_genai_semconv(span, event_name: str, data: dict, ide: str, session_ct
     provider = _infer_genai_provider(data)
     if provider is not None:
         span.set_attribute("gen_ai.provider.name", provider)
-    # Keep gen_ai.system aligned with the IDE identifier; provider identity is in gen_ai.provider.name.
-    span.set_attribute("gen_ai.system", ide)
+    span.set_attribute("gen_ai.system", _resolve_client_name(ide, data=data, session_ctx=session_ctx))
     span.set_attribute("gen_ai.operation.name", _genai_operation(event_name))
     _set_if_present(span, "gen_ai.conversation.id", data.get("conversation_id") or data.get("session_id"))
     _set_if_present(span, "gen_ai.agent.id", _first_present(data, ("agent_id",)))
@@ -2283,7 +2487,7 @@ def _apply_genai_semconv(span, event_name: str, data: dict, ide: str, session_ct
 def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Optional[dict] = None, batch_model: Optional[str] = None) -> None:
     """Attach all attributes to a span and emit OTel log records."""
     span.set_attribute("gen_ai.client.hook.event", event_name)
-    _set_client_identity_attributes(span, ide, data=data)
+    _set_client_identity_attributes(span, ide, data=data, session_ctx=session_ctx)
 
     # Optionally attach OS / host attributes on every span.
     # These are already present as resource attributes via OTEL_RESOURCE_ATTRIBUTES,
@@ -2459,12 +2663,7 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
     last_ts = batch[-1].get("timestamp_ns") or time.time_ns()
 
     # Use session trace context if available, so this generation shares the trace_id
-    parent_ctx = None
-    if session_ctx:
-        parent_ctx = _make_trace_context(
-            session_ctx.get("trace_id", "0"),
-            session_ctx.get("phantom_parent_id", "0"),
-        )
+    parent_ctx = _session_trace_context(session_ctx)
 
     # Scan batch for model (Fix B)
     batch_model = next(
@@ -2520,10 +2719,7 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush:
     start_ns = session_ctx.get("start_time_ns") or time.time_ns()
     end_ns = time.time_ns()
 
-    parent_ctx = _make_trace_context(
-        session_ctx.get("trace_id", "0"),
-        session_ctx.get("phantom_parent_id", "0"),
-    )
+    parent_ctx = _session_trace_context(session_ctx)
 
     span_kind = SpanKind.INTERNAL if SpanKind is not None else None
     session_span = tracer.start_span(
@@ -2564,6 +2760,9 @@ def main() -> int:
     event_name = _normalize_event(raw_event)
     ide = _detect_ide(data)
     sk = _session_key(data)
+    session_ctx = _load_session_context(sk)
+    session_ctx = _maybe_bind_session_to_upstream_context(sk, session_ctx, data)
+    agent_engine = _resolved_agent_engine(data, session_ctx)
 
     if _safe_bool(os.getenv("IDE_OTEL_LOG_EVENTS", "")):
         _LOGGER.info(
@@ -2574,8 +2773,6 @@ def main() -> int:
     # Fast path for buffered batch events (no span emission yet):
     # avoid loading OpenTelemetry SDK for events that only append to batch files.
     if _batch_enabled():
-        session_ctx = _load_session_context(sk)
-
         if event_name in _SESSION_START_EVENTS:
             if sk:
                 _create_session_context(sk, data, ide)
@@ -2599,7 +2796,7 @@ def main() -> int:
                 print(_continue_response_json())
                 return 0
 
-    if not _init_tracing(ide):
+    if not _init_tracing(ide, client_name=_resolve_client_name(ide, data=data, agent_engine=agent_engine, session_ctx=session_ctx)):
         print(_continue_response_json())
         return 0
 
@@ -2610,8 +2807,6 @@ def main() -> int:
     _flush_stale_sessions(tracer)
 
     try:
-        session_ctx = _load_session_context(sk)
-        agent_engine = _detect_agent_engine(data)
         if sk and session_ctx and agent_engine and agent_engine != ide and session_ctx.get("agent_engine") != agent_engine:
             session_ctx["agent_engine"] = agent_engine
             _write_session_context(sk, session_ctx)
@@ -2676,12 +2871,7 @@ def main() -> int:
                 _append_batch_event(gen_key, event_name, data)
             else:
                 # No generation context — emit as standalone span
-                parent_ctx = None
-                if session_ctx:
-                    parent_ctx = _make_trace_context(
-                        session_ctx.get("trace_id", "0"),
-                        session_ctx.get("phantom_parent_id", "0"),
-                    )
+                parent_ctx = _event_parent_trace_context(data, session_ctx)
                 with tracer.start_as_current_span(
                     f"gen_ai.client.hook.{event_name}", kind=SpanKind.INTERNAL,
                     context=parent_ctx,
@@ -2692,20 +2882,12 @@ def main() -> int:
             return 0
 
         # ── Streaming mode: emit spans immediately ──
-        parent_ctx = None
-        if session_ctx:
-            parent_ctx = _make_trace_context(
-                session_ctx.get("trace_id", "0"),
-                session_ctx.get("phantom_parent_id", "0"),
-            )
+        parent_ctx = _event_parent_trace_context(data, session_ctx)
 
         # Create session context on SessionStart even in streaming mode
         if event_name in _SESSION_START_EVENTS and sk and not session_ctx:
             session_ctx = _create_session_context(sk, data, ide)
-            parent_ctx = _make_trace_context(
-                session_ctx["trace_id"],
-                session_ctx["phantom_parent_id"],
-            )
+            parent_ctx = _event_parent_trace_context(data, session_ctx)
 
         with tracer.start_as_current_span(
             f"gen_ai.client.hook.{event_name}", kind=SpanKind.INTERNAL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentelemetry-hooks"
-dynamic = ["version"]
+version = "0.13.0"
 description = "OpenTelemetry integration for AI coding agents (Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}
@@ -33,6 +33,7 @@ Homepage = "https://github.com/o11y-dev/opentelemetry-hooks"
 Repository = "https://github.com/o11y-dev/opentelemetry-hooks"
 Documentation = "https://github.com/o11y-dev/opentelemetry-hooks#readme"
 Issues = "https://github.com/o11y-dev/opentelemetry-hooks/issues"
+Changelog = "https://github.com/o11y-dev/opentelemetry-hooks/blob/main/CHANGELOG.md"
 
 [project.scripts]
 otel-hook = "otel_hook:cli"
@@ -52,9 +53,6 @@ py-modules = ["otel_hook", "enrichment_connectors"]
     "examples/opencode-plugin.example.ts",
 ]
 
-[tool.setuptools_scm]
-fallback_version = "0.13.0"
-
 [tool.ruff]
 line-length = 120
 target-version = "py312"
@@ -64,7 +62,7 @@ select = ["E", "F", "W"]
 ignore = ["E501"]
 
 [tool.semantic_release]
-version_toml = []
+version_toml = ["pyproject.toml:project.version"]
 version_variables = []
 major_on_zero = false
 allow_zero_version = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentelemetry-hooks"
-dynamic = ["version"]
+version = "0.13.0"
 description = "OpenTelemetry integration for AI coding agents (Codex, Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}
@@ -62,11 +62,8 @@ target-version = "py312"
 select = ["E", "F", "W"]
 ignore = ["E501"]
 
-[tool.setuptools_scm]
-fallback_version = "0.13.0"
-
 [tool.semantic_release]
-version_toml = []
+version_toml = ["pyproject.toml:project.version"]
 version_variables = []
 major_on_zero = false
 allow_zero_version = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "opentelemetry-hooks"
 dynamic = ["version"]
-description = "OpenTelemetry integration for AI coding agents (Cursor IDE/CLI, GitHub Copilot, Claude Code, Antigravity, OpenCode-compatible runners)"
+description = "OpenTelemetry integration for AI coding agents (Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.12"
@@ -49,10 +49,11 @@ py-modules = ["otel_hook", "enrichment_connectors"]
     "examples/copilot-hooks.example.json",
     "examples/cursor-hooks.example.json",
     "examples/hooks.example.json",
+    "examples/opencode-plugin.example.ts",
 ]
 
 [tool.setuptools_scm]
-fallback_version = "0.1.0"
+fallback_version = "0.13.0"
 
 [tool.ruff]
 line-length = 120

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Bump version in pyproject.toml and stamp CHANGELOG.md with a release date."""
+
+from __future__ import annotations
+
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CHANGELOG = ROOT / "CHANGELOG.md"
+UNRELEASED_HEADING = re.compile(r"^## (?P<version>\d+\.\d+\.\d+) \(unreleased\)$", re.MULTILINE)
+
+
+def bump_pyproject(version: str) -> None:
+    text = PYPROJECT.read_text(encoding="utf-8")
+    updated = re.sub(
+        r'^version\s*=\s*"[^"]+"',
+        f'version = "{version}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if not re.search(r'^version\s*=\s*"[^"]+"', text, flags=re.MULTILINE):
+        print(f"warning: version string not found in {PYPROJECT}", file=sys.stderr)
+    PYPROJECT.write_text(updated, encoding="utf-8")
+
+
+def _validate_section_not_empty(version: str, changelog_path: Path) -> None:
+    """Fail if the stamped changelog section has no content."""
+    text = changelog_path.read_text(encoding="utf-8")
+    heading = re.compile(
+        rf"^## {re.escape(version)}(?: \([^)]+\))?\s*$",
+        flags=re.MULTILINE,
+    )
+    match = heading.search(text)
+    if not match:
+        return
+    next_heading = re.search(r"^##\s+", text[match.end() :], flags=re.MULTILINE)
+    end = match.end() + next_heading.start() if next_heading else len(text)
+    section = text[match.end() : end].strip()
+    if not section:
+        print(
+            f"error: changelog section for {version} in {changelog_path} is empty - "
+            "please add release notes before releasing",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def stamp_changelog(version: str, changelog_path: Path = CHANGELOG, *, today: str | None = None) -> None:
+    if not changelog_path.exists():
+        return
+    text = changelog_path.read_text(encoding="utf-8")
+
+    already_stamped = re.compile(
+        rf"^## {re.escape(version)} \(\d{{4}}-\d{{2}}-\d{{2}}\)\s*$",
+        flags=re.MULTILINE,
+    )
+    if already_stamped.search(text):
+        _validate_section_not_empty(version, changelog_path)
+        return
+
+    release_day = today or datetime.now(UTC).strftime("%Y-%m-%d")
+    exact_heading = re.compile(rf"^## {re.escape(version)} \(unreleased\)$", re.MULTILINE)
+    updated, replacements = exact_heading.subn(f"## {version} ({release_day})", text, count=1)
+    if replacements == 0:
+        updated, replacements = UNRELEASED_HEADING.subn(
+            f"## {version} ({release_day})",
+            text,
+            count=1,
+        )
+    if updated == text:
+        print(f"warning: no unreleased entry for {version} in {changelog_path}", file=sys.stderr)
+    changelog_path.write_text(updated, encoding="utf-8")
+    _validate_section_not_empty(version, changelog_path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: bump_version.py <version>", file=sys.stderr)
+        return 2
+    version = args[0]
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        print(f"error: version must be semver (e.g. 0.3.0), got: {version}", file=sys.stderr)
+        return 1
+    bump_pyproject(version)
+    stamp_changelog(version)
+    print(f"Bumped to {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Helpers for the GitHub release workflow."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+CHANGELOG = ROOT / "CHANGELOG.md"
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _validate_semver(version: str) -> str:
+    if not SEMVER_PATTERN.fullmatch(version):
+        raise ValueError(
+            f"version must be in semver format (MAJOR.MINOR.PATCH, e.g. 0.3.0), got: {version}"
+        )
+    return version
+
+
+def read_project_version(pyproject_path: Path = PYPROJECT) -> str:
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(f"{pyproject_path.name} not found") from exc
+
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        raise ValueError(f"{pyproject_path.name} is not valid TOML") from exc
+
+    try:
+        version = data["project"]["version"]
+    except KeyError as exc:
+        raise ValueError(f"{pyproject_path.name} missing [project].version") from exc
+
+    return _validate_semver(str(version))
+
+
+def version_tag_exists(version: str, root: Path = ROOT) -> bool:
+    result = subprocess.run(
+        ["git", "show-ref", "--tags", "--verify", "--quiet", f"refs/tags/v{version}"],
+        cwd=root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def parse_semantic_release_output(output: str) -> str | None:
+    if "No release will be made" in output:
+        return None
+
+    versions = [
+        line.strip()
+        for line in output.splitlines()
+        if SEMVER_PATTERN.fullmatch(line.strip())
+    ]
+    return versions[-1] if versions else None
+
+
+def determine_version(
+    *,
+    manual_version: str | None = None,
+    force: str | None = None,
+    root: Path = ROOT,
+    runner: Callable[..., Any] | None = None,
+) -> str | None:
+    if manual_version:
+        return _validate_semver(manual_version)
+
+    project_version = read_project_version(root / "pyproject.toml")
+    if not version_tag_exists(project_version, root):
+        return project_version
+
+    run_cmd = runner or subprocess.run
+    command = ["semantic-release", "version", "--print"]
+    if force:
+        command.append(f"--{force}")
+    result = run_cmd(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    return parse_semantic_release_output(output)
+
+
+def extract_release_notes(version: str, changelog_path: Path = CHANGELOG) -> str:
+    _validate_semver(version)
+    text = changelog_path.read_text(encoding="utf-8")
+    heading = re.compile(
+        rf"^## {re.escape(version)}(?: \([^)]+\))?\s*$",
+        flags=re.MULTILINE,
+    )
+    match = heading.search(text)
+    if not match:
+        raise ValueError(f"no changelog section found for {version}")
+
+    next_heading = re.search(r"^##\s+", text[match.end() :], flags=re.MULTILINE)
+    section_end = match.end() + next_heading.start() if next_heading else None
+    section = text[match.end() : section_end].strip()
+    if not section:
+        raise ValueError(f"changelog section for {version} is empty")
+    return f"{section}\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    determine = subparsers.add_parser("determine-version")
+    determine.add_argument("--version")
+    determine.add_argument("--force", choices=["patch", "minor", "major"])
+
+    notes = subparsers.add_parser("release-notes")
+    notes.add_argument("version")
+
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "determine-version":
+            version = determine_version(manual_version=args.version, force=args.force)
+            if version:
+                print(version)
+            return 0
+
+        print(extract_release_notes(args.version), end="")
+        return 0
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_workflow.py
+++ b/scripts/release_workflow.py
@@ -99,7 +99,10 @@ def determine_version(
 
 def extract_release_notes(version: str, changelog_path: Path = CHANGELOG) -> str:
     _validate_semver(version)
-    text = changelog_path.read_text(encoding="utf-8")
+    try:
+        text = changelog_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError) as exc:
+        raise ValueError(f"{changelog_path.name} not found") from exc
     heading = re.compile(
         rf"^## {re.escape(version)}(?: \([^)]+\))?\s*$",
         flags=re.MULTILINE,

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -156,6 +156,11 @@ class TestNormalizeInputData:
             "cacheReadInputTokens": 2,
             "agentName": "planner",
             "hookEventType": "PreToolUse",
+            "traceId": "a" * 32,
+            "spanId": "b" * 16,
+            "parentSpanId": "c" * 16,
+            "traceFlags": "01",
+            "traceState": "vendor=value",
         })
         assert data["session_id"] == "sess-1"
         assert data["request_model"] == "claude-3-7-sonnet"
@@ -170,6 +175,11 @@ class TestNormalizeInputData:
         assert data["cache_read_input_tokens"] == 2
         assert data["agent_name"] == "planner"
         assert data["hook_event_type"] == "PreToolUse"
+        assert data["trace_id"] == "a" * 32
+        assert data["span_id"] == "b" * 16
+        assert data["parent_span_id"] == "c" * 16
+        assert data["trace_flags"] == "01"
+        assert data["tracestate"] == "vendor=value"
 
     def test_returns_original_dict_when_no_aliases_are_needed(self):
         data = {"session_id": "sess-1"}
@@ -323,6 +333,18 @@ class TestDetectAgentEngine:
 
     def test_returns_none_without_engine_signal(self):
         assert otel_hook._detect_agent_engine({"session_id": "sess-1"}) is None
+
+    def test_detects_gemini_from_corroborated_semantic_fields(self):
+        assert otel_hook._detect_agent_engine({
+            "gen_ai.client.name": "gemini",
+            "service.name": "gemini-cli",
+        }) == "gemini"
+
+    def test_ignores_single_semantic_field_without_corroboration(self):
+        assert otel_hook._detect_agent_engine({
+            "gen_ai.system": "vscode",
+            "session_id": "sess-1",
+        }) is None
 
 
 # ── OpenCode plugin payload handling ──────────────────────────────────────
@@ -758,6 +780,34 @@ class TestGenAISemconv:
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "cursor"
 
+    def test_nested_agent_engine_becomes_genai_system(self):
+        span = mock.MagicMock()
+
+        otel_hook._apply_genai_semconv(
+            span,
+            "SubagentStop",
+            {"gen_ai.client.name": "gemini", "service.name": "gemini-cli"},
+            "claude",
+            session_ctx={"agent_engine": "gemini"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.system"] == "gemini"
+
+    def test_single_semantic_field_does_not_change_genai_system(self):
+        span = mock.MagicMock()
+
+        otel_hook._apply_genai_semconv(
+            span,
+            "UserPromptSubmit",
+            {"gen_ai.system": "vscode"},
+            "cursor",
+            session_ctx={},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.system"] == "cursor"
+
 
 class TestClientIdentityAttributes:
     @staticmethod
@@ -774,7 +824,8 @@ class TestClientIdentityAttributes:
         otel_hook._set_client_identity_attributes(span, "cursor", data={"session_id": "sess-1"})
 
         attrs = self._attrs(span)
-        assert attrs["gen_ai.client.name"] == "cursor"
+        assert attrs["gen_ai.client.name"] == "claude"
+        assert attrs["gen_ai.client.wrapper"] == "cursor"
         assert attrs["gen_ai.client.agent_engine"] == "claude"
 
     def test_omits_agent_engine_when_same_as_outer_ide(self):
@@ -784,6 +835,30 @@ class TestClientIdentityAttributes:
 
         attrs = self._attrs(span)
         assert attrs["gen_ai.client.name"] == "claude"
+        assert "gen_ai.client.agent_engine" not in attrs
+
+    def test_promotes_gemini_over_outer_claude(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"gen_ai.client.name": "gemini", "service.name": "gemini-cli"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "gemini"
+        assert attrs["gen_ai.client.wrapper"] == "claude"
+        assert attrs["gen_ai.client.agent_engine"] == "gemini"
+
+    def test_preserves_outer_agent_when_single_semantic_field_disagrees(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(span, "cursor", data={"gen_ai.system": "vscode"})
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "cursor"
+        assert "gen_ai.client.wrapper" not in attrs
         assert "gen_ai.client.agent_engine" not in attrs
 
 
@@ -920,6 +995,133 @@ class TestSessionContext:
     def test_load_missing_returns_none(self):
         assert otel_hook._load_session_context(None) is None
         assert otel_hook._load_session_context("nonexistent-session") is None
+
+    def test_create_uses_upstream_trace_context_when_present(self, tmp_path):
+        with mock.patch.object(otel_hook, "_SESSION_DIR", str(tmp_path)):
+            with mock.patch.object(otel_hook, "_LOCK_DIR", str(tmp_path / "locks")):
+                ctx = otel_hook._create_session_context(
+                    "sess-upstream",
+                    {"traceparent": f"00-{'a' * 32}-{'b' * 16}-00", "tracestate": "vendor=value"},
+                    "cursor",
+                )
+                assert ctx["trace_id"] == "a" * 32
+                assert ctx["upstream_parent_span_id"] == "b" * 16
+                assert ctx["trace_flags"] == "00"
+                assert ctx["tracestate"] == "vendor=value"
+                assert ctx["context_origin"] == "upstream"
+
+    def test_binds_existing_synthetic_session_to_first_upstream_context(self, tmp_path):
+        with mock.patch.object(otel_hook, "_SESSION_DIR", str(tmp_path)):
+            with mock.patch.object(otel_hook, "_LOCK_DIR", str(tmp_path / "locks")):
+                ctx = otel_hook._create_session_context("sess-bind", {}, "cursor")
+                assert ctx["context_origin"] == "synthetic"
+                updated = otel_hook._maybe_bind_session_to_upstream_context(
+                    "sess-bind",
+                    ctx,
+                    {"trace_id": "d" * 32, "span_id": "e" * 16},
+                )
+                assert updated["trace_id"] == "d" * 32
+                assert updated["upstream_parent_span_id"] == "e" * 16
+                assert updated["context_origin"] == "upstream"
+                loaded = otel_hook._load_session_context("sess-bind")
+                assert loaded["trace_id"] == "d" * 32
+                assert loaded["upstream_parent_span_id"] == "e" * 16
+
+
+class TestUpstreamTraceContext:
+    def test_parses_traceparent_payload(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"00-{'1' * 32}-{'2' * 16}-00",
+            "tracestate": "vendor=value",
+        })
+        assert ctx == {
+            "trace_id": "1" * 32,
+            "parent_span_id": "2" * 16,
+            "trace_flags": "00",
+            "tracestate": "vendor=value",
+        }
+
+    def test_parses_future_version_traceparent_with_extra_fields(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"01-{'1' * 32}-{'2' * 16}-00-extra-fields-allowed",
+        })
+        assert ctx == {
+            "trace_id": "1" * 32,
+            "parent_span_id": "2" * 16,
+            "trace_flags": "00",
+        }
+
+    def test_rejects_version_00_traceparent_with_extra_fields(self):
+        assert otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"00-{'1' * 32}-{'2' * 16}-00-extra-fields-not-allowed",
+        }) is None
+
+    def test_explicit_ids_prefer_current_span_id_as_parent(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "trace_id": "3" * 32,
+            "span_id": "4" * 16,
+            "parent_span_id": "5" * 16,
+            "trace_flags": "01",
+        })
+        assert ctx == {
+            "trace_id": "3" * 32,
+            "parent_span_id": "4" * 16,
+            "trace_flags": "01",
+        }
+
+    def test_reads_trace_context_from_env(self, monkeypatch):
+        monkeypatch.setenv("TRACEPARENT", f"00-{'6' * 32}-{'7' * 16}-01")
+        monkeypatch.setenv("TRACESTATE", "foo=bar")
+        ctx = otel_hook._resolve_upstream_trace_context({})
+        assert ctx == {
+            "trace_id": "6" * 32,
+            "parent_span_id": "7" * 16,
+            "trace_flags": "01",
+            "tracestate": "foo=bar",
+        }
+
+    def test_rejects_zero_trace_context(self):
+        assert otel_hook._resolve_upstream_trace_context({
+            "trace_id": "0" * 32,
+            "span_id": "1" * 16,
+        }) is None
+
+
+class TestTraceContextSelection:
+    def test_session_trace_context_prefers_upstream_parent(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            otel_hook,
+            "_make_trace_context",
+            lambda tid, sid, flags="01", tracestate=None: calls.append((tid, sid, flags, tracestate)) or "ctx",
+        )
+        session_ctx = {
+            "trace_id": "8" * 32,
+            "upstream_parent_span_id": "9" * 16,
+            "phantom_parent_id": "a" * 16,
+            "trace_flags": "00",
+            "tracestate": "vendor=value",
+        }
+        assert otel_hook._session_trace_context(session_ctx) == "ctx"
+        assert calls == [("8" * 32, "9" * 16, "00", "vendor=value")]
+
+    def test_event_context_overrides_session_fallback(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            otel_hook,
+            "_make_trace_context",
+            lambda tid, sid, flags="01", tracestate=None: calls.append((tid, sid, flags, tracestate)) or "ctx",
+        )
+        session_ctx = {
+            "trace_id": "b" * 32,
+            "upstream_parent_span_id": "c" * 16,
+            "phantom_parent_id": "d" * 16,
+        }
+        assert otel_hook._event_parent_trace_context(
+            {"trace_id": "e" * 32, "span_id": "f" * 16, "trace_flags": "00"},
+            session_ctx,
+        ) == "ctx"
+        assert calls == [("e" * 32, "f" * 16, "00", None)]
 
 
 # ── Generation advance ────────────────────────────────────────────────────
@@ -1061,7 +1263,7 @@ class TestMainFlow:
         """Main outputs legacy continue response by default."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO('{"hook_event_name":"stop"}'))
         # Prevent actual tracing init
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1093,7 +1295,7 @@ class TestMainFlow:
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: True)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: True)
         monkeypatch.setattr(otel_hook, "_flush_stale_sessions", lambda tracer: None)
         monkeypatch.setattr(otel_hook, "_force_flush_provider", lambda **kw: None)
         mock_span_cm = mock.MagicMock()
@@ -1115,7 +1317,7 @@ class TestMainFlow:
     def test_empty_input(self, monkeypatch):
         """Empty stdin should not crash."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO(""))
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1128,7 +1330,7 @@ class TestMainFlow:
     def test_malformed_json(self, monkeypatch):
         """Malformed JSON should not crash."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO("{bad json"))
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1148,7 +1350,7 @@ class TestMainFlow:
         appended = []
         monkeypatch.setattr(otel_hook, "_append_batch_event", lambda key, evt, data: appended.append((key, evt)))
         called = {"init": 0}
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: called.__setitem__("init", called["init"] + 1) or True)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: called.__setitem__("init", called["init"] + 1) or True)
         captured = []
         monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
         result = otel_hook.main()

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,285 @@
+import re
+from contextlib import redirect_stderr
+from importlib.util import module_from_spec, spec_from_file_location
+from io import StringIO
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+def _load_script(name: str):
+    repo_root = Path(__file__).resolve().parent.parent
+    module_path = repo_root / "scripts" / f"{name}.py"
+    spec = spec_from_file_location(f"test_{name}_module", module_path)
+    module = module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+release_workflow = _load_script("release_workflow")
+bump_version = _load_script("bump_version")
+
+
+def test_parse_semantic_release_output_ignores_already_released_version():
+    output = "\n".join([
+        "[20:31:38] WARNING  Token value is missing!",
+        "0.1.1",
+        "No release will be made, 0.1.1 has already been released!",
+    ])
+
+    assert release_workflow.parse_semantic_release_output(output) is None
+
+
+def test_determine_version_prefers_untagged_pyproject_version(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nversion = "0.2.0"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(release_workflow, "version_tag_exists", lambda version, root=None: False)
+    runner = Mock()
+    version = release_workflow.determine_version(root=tmp_path, runner=runner)
+
+    assert version == "0.2.0"
+    runner.assert_not_called()
+
+
+def test_determine_version_uses_semantic_release_when_tag_exists(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nversion = "0.1.1"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(release_workflow, "version_tag_exists", lambda version, root: True)
+    runner = Mock(return_value=Mock(stdout="0.2.0\n", stderr="", returncode=0))
+
+    version = release_workflow.determine_version(root=tmp_path, force="minor", runner=runner)
+
+    assert version == "0.2.0"
+    runner.assert_called_once()
+    assert runner.call_args.args[0] == ["semantic-release", "version", "--print", "--minor"]
+
+
+def test_version_tag_exists_checks_tag_namespace_only(monkeypatch):
+    run = Mock(return_value=Mock(returncode=0))
+    monkeypatch.setattr(release_workflow.subprocess, "run", run)
+
+    assert release_workflow.version_tag_exists("0.2.0") is True
+    assert run.call_args.args[0] == [
+        "git",
+        "show-ref",
+        "--tags",
+        "--verify",
+        "--quiet",
+        "refs/tags/v0.2.0",
+    ]
+
+
+def test_version_tag_exists_returns_false_when_tag_is_missing(monkeypatch):
+    run = Mock(return_value=Mock(returncode=1))
+    monkeypatch.setattr(release_workflow.subprocess, "run", run)
+
+    assert release_workflow.version_tag_exists("0.2.0") is False
+
+
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        (None, "pyproject.toml not found"),
+        ("not = [valid", "pyproject.toml is not valid TOML"),
+        ("[project]\nname = 'opentelemetry-hooks'\n", "pyproject.toml missing [project].version"),
+    ],
+)
+def test_read_project_version_reports_common_configuration_errors(
+    tmp_path: Path, contents: str | None, message: str
+):
+    pyproject = tmp_path / "pyproject.toml"
+    if contents is not None:
+        pyproject.write_text(contents, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        release_workflow.read_project_version(pyproject)
+
+
+def test_extract_release_notes_uses_requested_section_only(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.3.0 (unreleased)",
+            "",
+            "### Added",
+            "- future work",
+            "",
+            "## 0.2.0 (2026-04-13)",
+            "",
+            "### Added",
+            "- shipped change",
+            "",
+            "### Fixed",
+            "- released fix",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    notes = release_workflow.extract_release_notes("0.2.0", changelog)
+
+    assert notes == "### Added\n- shipped change\n\n### Fixed\n- released fix\n"
+    assert "future work" not in notes
+
+
+def test_extract_release_notes_requires_existing_section(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no changelog section found for 0.2.0"):
+        release_workflow.extract_release_notes("0.2.0", changelog)
+
+
+def test_extract_release_notes_raises_on_empty_section(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.3.0 (2026-04-14)",
+            "",
+            "## 0.2.1 (2026-04-14)",
+            "",
+            "### Added",
+            "- shipped change",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="changelog section for 0.3.0 is empty"):
+        release_workflow.extract_release_notes("0.3.0", changelog)
+
+
+def test_stamp_changelog_updates_matching_unreleased_section(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.2.1 (unreleased)",
+            "",
+            "- shipped change",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    bump_version.stamp_changelog("0.2.1", changelog, today="2026-04-14")
+
+    assert "## 0.2.1 (2026-04-14)" in changelog.read_text(encoding="utf-8")
+
+
+def test_stamp_changelog_promotes_first_unreleased_section_when_versions_differ(
+    tmp_path: Path,
+):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.3.0 (unreleased)",
+            "",
+            "### Added",
+            "- shipped change",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    bump_version.stamp_changelog("0.2.1", changelog, today="2026-04-14")
+
+    stamped = changelog.read_text(encoding="utf-8")
+    assert "## 0.2.1 (2026-04-14)" in stamped
+    assert "0.3.0 (unreleased)" not in stamped
+
+
+def test_stamp_changelog_skips_when_already_stamped_and_has_content(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    original = "\n".join([
+        "# Changelog",
+        "",
+        "## 0.3.1 (unreleased)",
+        "",
+        "## 0.3.0 (2026-04-14)",
+        "",
+        "### Added",
+        "- a real change",
+        "",
+        "## 0.2.1 (2026-04-14)",
+        "",
+        "### Added",
+        "- older change",
+        "",
+    ])
+    changelog.write_text(original, encoding="utf-8")
+
+    bump_version.stamp_changelog("0.3.0", changelog, today="2026-04-14")
+
+    result = changelog.read_text(encoding="utf-8")
+    assert result == original
+    assert result.count("## 0.3.0") == 1
+
+
+def test_stamp_changelog_rejects_empty_section(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.3.0 (unreleased)",
+            "",
+            "## 0.2.1 (2026-04-14)",
+            "",
+            "### Added",
+            "- shipped change",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        bump_version.stamp_changelog("0.3.0", changelog, today="2026-04-14")
+
+
+def test_stamp_changelog_succeeds_with_content(tmp_path: Path):
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        "\n".join([
+            "# Changelog",
+            "",
+            "## 0.3.0 (unreleased)",
+            "",
+            "### Added",
+            "- a real change",
+            "",
+            "## 0.2.1 (2026-04-14)",
+            "",
+        ]),
+        encoding="utf-8",
+    )
+
+    bump_version.stamp_changelog("0.3.0", changelog, today="2026-04-14")
+    assert "## 0.3.0 (2026-04-14)" in changelog.read_text(encoding="utf-8")
+
+
+def test_stamp_changelog_warning_mentions_actual_path(tmp_path: Path):
+    changelog = tmp_path / "nested" / "CHANGELOG.md"
+    changelog.parent.mkdir()
+    changelog.write_text("# Changelog\n", encoding="utf-8")
+    stderr = StringIO()
+
+    with redirect_stderr(stderr):
+        bump_version.stamp_changelog("0.2.1", changelog, today="2026-04-14")
+
+    assert str(changelog) in stderr.getvalue()

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -12,8 +12,8 @@ def _load_script(name: str):
     repo_root = Path(__file__).resolve().parent.parent
     module_path = repo_root / "scripts" / f"{name}.py"
     spec = spec_from_file_location(f"test_{name}_module", module_path)
+    assert spec is not None and spec.loader is not None, f"Could not load spec for {module_path}"
     module = module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
     spec.loader.exec_module(module)
     return module
 


### PR DESCRIPTION
## Summary

- Clarify supported agent setup with a README setup matrix and refreshed quick-start commands.
- Document Gemini CLI setup and fix source-checkout paths for setup, examples, config, and logs.
- Bump release references to `v0.13.0` and move the package to a checked-in `pyproject.toml` version.
- Add `CHANGELOG.md`, release helper scripts, and tests modeled after `reflect`.
- Update the release workflow to stamp `pyproject.toml` / `README.md` / `CHANGELOG.md`, build changelog-derived release notes, tag, publish GitHub releases, and publish to PyPI from the tag.

## Validation

- `.venv312/bin/python -m pytest tests/test_release_workflow.py tests/test_update_readme_release_refs.py tests/test_cli.py -q`
- `.venv312/bin/ruff check .`
- `.venv312/bin/python -m build --no-isolation`
- `python3.12 scripts/release_workflow.py determine-version`
- `python3.12 scripts/release_workflow.py release-notes 0.13.0`

## Notes

The release flow now follows the `reflect` pattern: `pyproject.toml` owns the version, `CHANGELOG.md` owns release notes, and the release workflow stamps both before creating the `vX.Y.Z` tag. Local validation used a temporary Python 3.12 venv because the default `python3` on this machine is 3.9; the venv was removed after validation.