### PR TITLE
Preserve upstream trace context and normalize agent attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,12 +721,14 @@ Example: `https://ingress.us1.coralogix.com:443/v1/traces` → `https://ingress.
 
 When `IDE_OTEL_BATCH_ON_STOP=true` (recommended):
 
-1. **SessionStart**: Pre-generates a `trace_id` shared by all spans in the session. Stored in `.state/sessions/`.
+1. **SessionStart**: If the hook receives upstream trace context (`traceparent` / `TRACEPARENT`, or explicit `trace_id` + `span_id` / `parent_span_id`), it adopts that real `trace_id` and parent span for the session. Otherwise it pre-generates a synthetic `trace_id`. State is stored in `.state/sessions/`.
 2. **Generation events**: Buffered to `.state/batches/<generation_id>.jsonl`.
 3. **Stop**: Flushes the generation's events as a `gen_ai.client.generation` span with child event spans. All share the session's `trace_id`. Exported immediately to avoid data loss.
 4. **SessionEnd**: Emits the root `gen_ai.client.session` span covering the full session duration. Cleans up state files.
 
 For IDEs without a `generation_id` (Copilot), the hook auto-derives generation boundaries from `UserPromptSubmit` → `Stop` cycles using an internal counter.
+
+When upstream context is present, hook spans keep the real `trace_id` and attach to the real upstream parent span. The hook still cannot force a specific emitted `span_id` for its own spans because the Python OpenTelemetry SDK assigns span IDs when spans are started.
 
 ## IDE Detection
 
@@ -744,7 +746,7 @@ The hook auto-detects which IDE is calling it:
 
 Detection order is: (1) parent process tree, (2) explicit `IDE_OTEL_IDE_NAME`, (3) self-reported payload fields, then (4) heuristics. `setup.sh` now relies on process discovery for generated Cursor, Copilot, and Claude configs, while the env var remains available as an escape hatch for generic runners and debugging.
 
-The detected outer IDE is recorded on spans as `gen_ai.client.name` and is also exported as the `gen_ai.system` resource attribute via `OTEL_RESOURCE_ATTRIBUTES` for backward compatibility. When nested signals indicate a different inner engine (for example Cursor hosting Claude Code), the hook additionally records `gen_ai.client.agent_engine`. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
+The hook still detects the outer wrapper IDE/process, but the emitted canonical client identity now prefers a distinct inner engine when one is present (for example Gemini running under Claude Code). In that case, spans/resources use the inner engine for `gen_ai.client.name` and `gen_ai.system`, keep `gen_ai.client.agent_engine` for compatibility, and record the wrapper as `gen_ai.client.wrapper`. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
 
 ## File Structure
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -262,6 +262,7 @@ _MDM_REGISTRY_PATH = r"SOFTWARE\Policies\OpenTelemetryHook"  # Windows registry 
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 _TOKEN_RE = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
 _HOME_RE = re.compile(r"/Users/[^/\s]+")
+_HEX_DIGITS = frozenset("0123456789abcdef")
 _TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 
@@ -2242,7 +2243,7 @@ def _parse_traceparent(value: Optional[str]) -> Optional[dict]:
         return None
     if version != "00" and len(parts) > 4 and any(part == "" for part in parts[4:]):
         return None
-    if not re.fullmatch(r"[0-9a-f]{2}", version) or not re.fullmatch(r"[0-9a-f]{2}", trace_flags):
+    if any(ch not in _HEX_DIGITS for ch in version) or any(ch not in _HEX_DIGITS for ch in trace_flags):
         return None
     if not _TRACE_ID_RE.match(trace_id) or not _SPAN_ID_RE.match(span_id):
         return None

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -262,6 +262,11 @@ _MDM_REGISTRY_PATH = r"SOFTWARE\Policies\OpenTelemetryHook"  # Windows registry 
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 _TOKEN_RE = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
 _HOME_RE = re.compile(r"/Users/[^/\s]+")
+_TRACEPARENT_RE = re.compile(
+    r"^(?P<version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$"
+)
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +397,11 @@ _INPUT_ALIASES = {
     "appVersion": "app_version",
     "ideName": "ide_name",
     "sourceApp": "source_app",
+    "traceId": "trace_id",
+    "spanId": "span_id",
+    "parentSpanId": "parent_span_id",
+    "traceFlags": "trace_flags",
+    "traceState": "tracestate",
 }
 
 # Canonical gen_ai.client.name values accepted directly from IDE_OTEL_IDE_NAME or
@@ -519,6 +529,14 @@ def _first_present(data: dict, keys: tuple):
     for key in keys:
         if key in data and data[key] is not None:
             return data[key]
+    return None
+
+
+def _first_env(keys: tuple[str, ...]) -> Optional[str]:
+    for key in keys:
+        value = os.getenv(key)
+        if value:
+            return value
     return None
 
 
@@ -663,7 +681,15 @@ def _detect_client_version(data: dict, ide: str) -> Optional[str]:
 
 def _detect_agent_engine(data: dict) -> Optional[str]:
     """Detect an inner agent engine without consulting IDE_OTEL_IDE_NAME."""
-    explicit = _normalize_ide_name(_first_present(data, ("agent_engine", "agentEngine", "engine", "engine_name")))
+    explicit = _normalize_ide_name(_first_present(
+        data,
+        (
+            "agent_engine",
+            "agentEngine",
+            "engine",
+            "engine_name",
+        ),
+    ))
     if explicit:
         return explicit
 
@@ -680,6 +706,19 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     if reported:
         return reported
 
+    semantic_signals = [
+        _normalize_ide_name(_first_present(data, ("gen_ai.client.name",))),
+        _normalize_ide_name(_first_present(data, ("gen_ai.system",))),
+        _normalize_ide_name(_first_present(data, ("service.name", "service_name"))),
+    ]
+    semantic_counts: dict[str, int] = {}
+    for signal in semantic_signals:
+        if signal:
+            semantic_counts[signal] = semantic_counts.get(signal, 0) + 1
+    corroborated = [name for name, count in semantic_counts.items() if count >= 2]
+    if len(corroborated) == 1:
+        return corroborated[0]
+
     raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
     if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
         return "claude"
@@ -687,17 +726,40 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     return None
 
 
+def _resolved_agent_engine(data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> Optional[str]:
+    resolved = _detect_agent_engine(data or {})
+    if resolved:
+        return resolved
+    if session_ctx:
+        return _normalize_ide_name(session_ctx.get("agent_engine"))
+    return None
+
+
+def _resolve_client_name(
+    ide: str,
+    data: Optional[dict] = None,
+    agent_engine: Optional[str] = None,
+    session_ctx: Optional[dict] = None,
+) -> str:
+    resolved_engine = agent_engine if agent_engine is not None else _resolved_agent_engine(data, session_ctx)
+    if resolved_engine and resolved_engine != ide:
+        return resolved_engine
+    return ide
+
+
 def _set_client_identity_attributes(
-    span, ide: str, data: Optional[dict] = None, agent_engine: Optional[str] = None,
+    span, ide: str, data: Optional[dict] = None, agent_engine: Optional[str] = None, session_ctx: Optional[dict] = None,
 ) -> Optional[str]:
-    """Attach outer IDE identity and, when distinct, the inner agent engine.
+    """Attach canonical client identity and preserve wrapper identity when nested.
 
     Returns the resolved inner engine when one is detected and differs from the
     outer IDE; otherwise returns ``None``.
     """
-    span.set_attribute("gen_ai.client.name", ide)
-    resolved_engine = agent_engine if agent_engine is not None else _detect_agent_engine(data or {})
+    resolved_engine = agent_engine if agent_engine is not None else _resolved_agent_engine(data, session_ctx)
+    client_name = _resolve_client_name(ide, data=data, agent_engine=resolved_engine, session_ctx=session_ctx)
+    span.set_attribute("gen_ai.client.name", client_name)
     if resolved_engine and resolved_engine != ide:
+        span.set_attribute("gen_ai.client.wrapper", ide)
         span.set_attribute("gen_ai.client.agent_engine", resolved_engine)
         return resolved_engine
     return None
@@ -1465,7 +1527,7 @@ def _force_flush_provider(timeout_millis: int = 500) -> None:
         _LOGGER.warning("log force_flush failed: %s", exc)
 
 
-def _init_tracing(ide: str = "cursor") -> bool:
+def _init_tracing(ide: str = "cursor", client_name: Optional[str] = None) -> bool:
     global _TRACING_INITIALIZED
     if _TRACING_INITIALIZED:
         return True
@@ -1478,9 +1540,13 @@ def _init_tracing(ide: str = "cursor") -> bool:
         os.environ["OTEL_SERVICE_NAME"] = service_name
 
     app_name = os.getenv("IDE_OTEL_APP_NAME") or os.getenv("OTEL_SERVICE_NAME") or "ide-agent"
+    resolved_client_name = client_name or ide
     resource_attrs = _parse_resource_attributes(os.getenv("OTEL_RESOURCE_ATTRIBUTES", ""))
     resource_attrs.setdefault("service.name", app_name)
-    resource_attrs.setdefault("gen_ai.system", ide)
+    resource_attrs.setdefault("gen_ai.client.name", resolved_client_name)
+    resource_attrs.setdefault("gen_ai.system", resolved_client_name)
+    if ide != resolved_client_name:
+        resource_attrs.setdefault("gen_ai.client.wrapper", ide)
 
     # OS / host resource attributes (OTel semantic conventions)
     os_info = _get_os_info()
@@ -1947,16 +2013,25 @@ def _session_path(session_key: str) -> str:
 
 
 def _create_session_context(session_key: str, data: dict, ide: str) -> dict:
-    """Create and persist a new session context with pre-generated trace IDs."""
+    """Create and persist a new session context with upstream or synthetic trace IDs."""
     os.makedirs(_SESSION_DIR, exist_ok=True)
+    upstream_ctx = _resolve_upstream_trace_context(data)
     ctx = {
-        "trace_id": f"{random.getrandbits(128):032x}",
         "phantom_parent_id": f"{random.getrandbits(64):016x}",
+        "trace_id": f"{random.getrandbits(128):032x}",
         "start_time_ns": time.time_ns(),
         "ide": ide,
         "generation_count": 0,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        "context_origin": "synthetic",
     }
+    if upstream_ctx is not None:
+        ctx["trace_id"] = upstream_ctx["trace_id"]
+        ctx["upstream_parent_span_id"] = upstream_ctx["parent_span_id"]
+        ctx["trace_flags"] = upstream_ctx.get("trace_flags", "01")
+        if upstream_ctx.get("tracestate"):
+            ctx["tracestate"] = upstream_ctx["tracestate"]
+        ctx["context_origin"] = "upstream"
     if model := _first_present(data, ("request_model", "model", "model_name")):
         ctx["last_known_model"] = model
 
@@ -1987,6 +2062,24 @@ def _write_session_context(session_key: str, ctx: dict) -> None:
     lock_path = os.path.join(_LOCK_DIR, f"{re.sub(r'[^A-Za-z0-9_.-]+', '_', session_key)}.lock")
     with _acquire_lock(lock_path):
         _atomic_write_json(_session_path(session_key), ctx)
+
+
+def _maybe_bind_session_to_upstream_context(session_key: Optional[str], session_ctx: Optional[dict], data: dict) -> Optional[dict]:
+    if not session_key or not session_ctx or session_ctx.get("context_origin") == "upstream":
+        return session_ctx
+    upstream_ctx = _resolve_upstream_trace_context(data)
+    if upstream_ctx is None:
+        return session_ctx
+    session_ctx["trace_id"] = upstream_ctx["trace_id"]
+    session_ctx["upstream_parent_span_id"] = upstream_ctx["parent_span_id"]
+    session_ctx["trace_flags"] = upstream_ctx.get("trace_flags", "01")
+    if upstream_ctx.get("tracestate"):
+        session_ctx["tracestate"] = upstream_ctx["tracestate"]
+    else:
+        session_ctx.pop("tracestate", None)
+    session_ctx["context_origin"] = "upstream"
+    _write_session_context(session_key, session_ctx)
+    return session_ctx
 
 
 def _clear_session_context(session_key: Optional[str]) -> None:
@@ -2137,7 +2230,74 @@ def _clear_batch_events(key: str) -> None:
 # ---------------------------------------------------------------------------
 # Trace context helpers
 # ---------------------------------------------------------------------------
-def _make_trace_context(trace_id_hex: str, span_id_hex: str):
+def _parse_traceparent(value: Optional[str]) -> Optional[dict]:
+    if not isinstance(value, str):
+        return None
+    match = _TRACEPARENT_RE.match(value.strip().lower())
+    if match is None or match.group("version") == "ff":
+        return None
+    trace_id = match.group("trace_id")
+    span_id = match.group("span_id")
+    if trace_id == "0" * 32 or span_id == "0" * 16:
+        return None
+    return {
+        "trace_id": trace_id,
+        "parent_span_id": span_id,
+        "trace_flags": match.group("trace_flags"),
+    }
+
+
+def _resolve_upstream_trace_context(data: Optional[dict]) -> Optional[dict]:
+    data = data or {}
+    tracestate = _first_present(data, ("tracestate",)) or _first_env(
+        ("IDE_OTEL_TRACESTATE", "TRACESTATE", "OTEL_TRACESTATE")
+    )
+    traceparent = _first_present(data, ("traceparent",)) or _first_env(
+        ("IDE_OTEL_TRACEPARENT", "TRACEPARENT", "OTEL_TRACEPARENT")
+    )
+    parsed = _parse_traceparent(traceparent)
+    if parsed is not None:
+        if isinstance(tracestate, str) and tracestate.strip():
+            parsed["tracestate"] = tracestate.strip()
+        return parsed
+
+    trace_id = _lower_or_none(_first_present(data, ("trace_id",)) or _first_env(
+        ("IDE_OTEL_TRACE_ID", "TRACE_ID", "OTEL_TRACE_ID")
+    ))
+    span_id = _lower_or_none(_first_present(data, ("span_id",)) or _first_env(
+        ("IDE_OTEL_SPAN_ID", "SPAN_ID", "OTEL_SPAN_ID")
+    ))
+    parent_span_id = _lower_or_none(_first_present(data, ("parent_span_id",)) or _first_env(
+        ("IDE_OTEL_PARENT_SPAN_ID", "PARENT_SPAN_ID", "OTEL_PARENT_SPAN_ID")
+    ))
+    trace_flags = _lower_or_none(_first_present(data, ("trace_flags",)) or _first_env(
+        ("IDE_OTEL_TRACE_FLAGS", "TRACE_FLAGS", "OTEL_TRACE_FLAGS")
+    )) or "01"
+    effective_parent_span_id = span_id or parent_span_id
+    if trace_id is None or effective_parent_span_id is None:
+        return None
+    if not _TRACE_ID_RE.match(trace_id) or trace_id == "0" * 32:
+        return None
+    if not _SPAN_ID_RE.match(effective_parent_span_id) or effective_parent_span_id == "0" * 16:
+        return None
+    if not re.fullmatch(r"[0-9a-f]{2}", trace_flags):
+        trace_flags = "01"
+    ctx = {
+        "trace_id": trace_id,
+        "parent_span_id": effective_parent_span_id,
+        "trace_flags": trace_flags,
+    }
+    if isinstance(tracestate, str) and tracestate.strip():
+        ctx["tracestate"] = tracestate.strip()
+    return ctx
+
+
+def _make_trace_context(
+    trace_id_hex: str,
+    span_id_hex: str,
+    trace_flags_hex: str = "01",
+    tracestate_header: Optional[str] = None,
+):
     """Create an OTel context from hex trace/span IDs for cross-process linking."""
     if SpanContext is None:
         return None
@@ -2148,11 +2308,47 @@ def _make_trace_context(trace_id_hex: str, span_id_hex: str):
         return None
     if not tid or not sid:
         return None
+    trace_flags = TraceFlags(TraceFlags.SAMPLED)
+    try:
+        trace_flags = TraceFlags(int(trace_flags_hex, 16) & 0xFF)
+    except (ValueError, TypeError):
+        pass
+    trace_state = TraceState()
+    if tracestate_header and hasattr(TraceState, "from_header"):
+        try:
+            parsed_state = TraceState.from_header([tracestate_header])
+            if parsed_state is not None:
+                trace_state = parsed_state
+        except Exception:
+            pass
     ctx = SpanContext(
         trace_id=tid, span_id=sid, is_remote=True,
-        trace_flags=TraceFlags(TraceFlags.SAMPLED), trace_state=TraceState(),
+        trace_flags=trace_flags, trace_state=trace_state,
     )
     return trace.set_span_in_context(NonRecordingSpan(ctx))
+
+
+def _session_trace_context(session_ctx: Optional[dict]):
+    if not session_ctx:
+        return None
+    return _make_trace_context(
+        session_ctx.get("trace_id", "0"),
+        session_ctx.get("upstream_parent_span_id") or session_ctx.get("phantom_parent_id", "0"),
+        session_ctx.get("trace_flags", "01"),
+        session_ctx.get("tracestate"),
+    )
+
+
+def _event_parent_trace_context(data: dict, session_ctx: Optional[dict]):
+    upstream_ctx = _resolve_upstream_trace_context(data)
+    if upstream_ctx is not None:
+        return _make_trace_context(
+            upstream_ctx["trace_id"],
+            upstream_ctx["parent_span_id"],
+            upstream_ctx.get("trace_flags", "01"),
+            upstream_ctx.get("tracestate"),
+        )
+    return _session_trace_context(session_ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -2182,8 +2378,7 @@ def _apply_genai_semconv(span, event_name: str, data: dict, ide: str, session_ct
     provider = _infer_genai_provider(data)
     if provider is not None:
         span.set_attribute("gen_ai.provider.name", provider)
-    # Keep gen_ai.system aligned with the IDE identifier; provider identity is in gen_ai.provider.name.
-    span.set_attribute("gen_ai.system", ide)
+    span.set_attribute("gen_ai.system", _resolve_client_name(ide, data=data, session_ctx=session_ctx))
     span.set_attribute("gen_ai.operation.name", _genai_operation(event_name))
     _set_if_present(span, "gen_ai.conversation.id", data.get("conversation_id") or data.get("session_id"))
     _set_if_present(span, "gen_ai.agent.id", _first_present(data, ("agent_id",)))
@@ -2283,7 +2478,7 @@ def _apply_genai_semconv(span, event_name: str, data: dict, ide: str, session_ct
 def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Optional[dict] = None, batch_model: Optional[str] = None) -> None:
     """Attach all attributes to a span and emit OTel log records."""
     span.set_attribute("gen_ai.client.hook.event", event_name)
-    _set_client_identity_attributes(span, ide, data=data)
+    _set_client_identity_attributes(span, ide, data=data, session_ctx=session_ctx)
 
     # Optionally attach OS / host attributes on every span.
     # These are already present as resource attributes via OTEL_RESOURCE_ATTRIBUTES,
@@ -2459,12 +2654,7 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
     last_ts = batch[-1].get("timestamp_ns") or time.time_ns()
 
     # Use session trace context if available, so this generation shares the trace_id
-    parent_ctx = None
-    if session_ctx:
-        parent_ctx = _make_trace_context(
-            session_ctx.get("trace_id", "0"),
-            session_ctx.get("phantom_parent_id", "0"),
-        )
+    parent_ctx = _session_trace_context(session_ctx)
 
     # Scan batch for model (Fix B)
     batch_model = next(
@@ -2520,10 +2710,7 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush:
     start_ns = session_ctx.get("start_time_ns") or time.time_ns()
     end_ns = time.time_ns()
 
-    parent_ctx = _make_trace_context(
-        session_ctx.get("trace_id", "0"),
-        session_ctx.get("phantom_parent_id", "0"),
-    )
+    parent_ctx = _session_trace_context(session_ctx)
 
     span_kind = SpanKind.INTERNAL if SpanKind is not None else None
     session_span = tracer.start_span(
@@ -2564,6 +2751,9 @@ def main() -> int:
     event_name = _normalize_event(raw_event)
     ide = _detect_ide(data)
     sk = _session_key(data)
+    session_ctx = _load_session_context(sk)
+    session_ctx = _maybe_bind_session_to_upstream_context(sk, session_ctx, data)
+    agent_engine = _resolved_agent_engine(data, session_ctx)
 
     if _safe_bool(os.getenv("IDE_OTEL_LOG_EVENTS", "")):
         _LOGGER.info(
@@ -2574,8 +2764,6 @@ def main() -> int:
     # Fast path for buffered batch events (no span emission yet):
     # avoid loading OpenTelemetry SDK for events that only append to batch files.
     if _batch_enabled():
-        session_ctx = _load_session_context(sk)
-
         if event_name in _SESSION_START_EVENTS:
             if sk:
                 _create_session_context(sk, data, ide)
@@ -2599,7 +2787,7 @@ def main() -> int:
                 print(_continue_response_json())
                 return 0
 
-    if not _init_tracing(ide):
+    if not _init_tracing(ide, client_name=_resolve_client_name(ide, data=data, agent_engine=agent_engine, session_ctx=session_ctx)):
         print(_continue_response_json())
         return 0
 
@@ -2610,8 +2798,6 @@ def main() -> int:
     _flush_stale_sessions(tracer)
 
     try:
-        session_ctx = _load_session_context(sk)
-        agent_engine = _detect_agent_engine(data)
         if sk and session_ctx and agent_engine and agent_engine != ide and session_ctx.get("agent_engine") != agent_engine:
             session_ctx["agent_engine"] = agent_engine
             _write_session_context(sk, session_ctx)
@@ -2676,12 +2862,7 @@ def main() -> int:
                 _append_batch_event(gen_key, event_name, data)
             else:
                 # No generation context — emit as standalone span
-                parent_ctx = None
-                if session_ctx:
-                    parent_ctx = _make_trace_context(
-                        session_ctx.get("trace_id", "0"),
-                        session_ctx.get("phantom_parent_id", "0"),
-                    )
+                parent_ctx = _event_parent_trace_context(data, session_ctx)
                 with tracer.start_as_current_span(
                     f"gen_ai.client.hook.{event_name}", kind=SpanKind.INTERNAL,
                     context=parent_ctx,
@@ -2692,20 +2873,12 @@ def main() -> int:
             return 0
 
         # ── Streaming mode: emit spans immediately ──
-        parent_ctx = None
-        if session_ctx:
-            parent_ctx = _make_trace_context(
-                session_ctx.get("trace_id", "0"),
-                session_ctx.get("phantom_parent_id", "0"),
-            )
+        parent_ctx = _event_parent_trace_context(data, session_ctx)
 
         # Create session context on SessionStart even in streaming mode
         if event_name in _SESSION_START_EVENTS and sk and not session_ctx:
             session_ctx = _create_session_context(sk, data, ide)
-            parent_ctx = _make_trace_context(
-                session_ctx["trace_id"],
-                session_ctx["phantom_parent_id"],
-            )
+            parent_ctx = _event_parent_trace_context(data, session_ctx)
 
         with tracer.start_as_current_span(
             f"gen_ai.client.hook.{event_name}", kind=SpanKind.INTERNAL,

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -262,9 +262,6 @@ _MDM_REGISTRY_PATH = r"SOFTWARE\Policies\OpenTelemetryHook"  # Windows registry 
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
 _TOKEN_RE = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
 _HOME_RE = re.compile(r"/Users/[^/\s]+")
-_TRACEPARENT_RE = re.compile(
-    r"^(?P<version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-(?P<span_id>[0-9a-f]{16})-(?P<trace_flags>[0-9a-f]{2})$"
-)
 _TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 _SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 
@@ -2233,17 +2230,28 @@ def _clear_batch_events(key: str) -> None:
 def _parse_traceparent(value: Optional[str]) -> Optional[dict]:
     if not isinstance(value, str):
         return None
-    match = _TRACEPARENT_RE.match(value.strip().lower())
-    if match is None or match.group("version") == "ff":
+    parts = value.strip().lower().split("-")
+    if len(parts) < 4:
         return None
-    trace_id = match.group("trace_id")
-    span_id = match.group("span_id")
+    version, trace_id, span_id, trace_flags = parts[:4]
+    if version == "ff":
+        return None
+    if len(version) != 2 or len(trace_flags) != 2:
+        return None
+    if version == "00" and len(parts) != 4:
+        return None
+    if version != "00" and len(parts) > 4 and any(part == "" for part in parts[4:]):
+        return None
+    if not re.fullmatch(r"[0-9a-f]{2}", version) or not re.fullmatch(r"[0-9a-f]{2}", trace_flags):
+        return None
+    if not _TRACE_ID_RE.match(trace_id) or not _SPAN_ID_RE.match(span_id):
+        return None
     if trace_id == "0" * 32 or span_id == "0" * 16:
         return None
     return {
         "trace_id": trace_id,
         "parent_span_id": span_id,
-        "trace_flags": match.group("trace_flags"),
+        "trace_flags": trace_flags,
     }
 
 

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1041,6 +1041,21 @@ class TestUpstreamTraceContext:
             "tracestate": "vendor=value",
         }
 
+    def test_parses_future_version_traceparent_with_extra_fields(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"01-{'1' * 32}-{'2' * 16}-00-extra-fields-allowed",
+        })
+        assert ctx == {
+            "trace_id": "1" * 32,
+            "parent_span_id": "2" * 16,
+            "trace_flags": "00",
+        }
+
+    def test_rejects_version_00_traceparent_with_extra_fields(self):
+        assert otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"00-{'1' * 32}-{'2' * 16}-00-extra-fields-not-allowed",
+        }) is None
+
     def test_explicit_ids_prefer_current_span_id_as_parent(self):
         ctx = otel_hook._resolve_upstream_trace_context({
             "trace_id": "3" * 32,

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -156,6 +156,11 @@ class TestNormalizeInputData:
             "cacheReadInputTokens": 2,
             "agentName": "planner",
             "hookEventType": "PreToolUse",
+            "traceId": "a" * 32,
+            "spanId": "b" * 16,
+            "parentSpanId": "c" * 16,
+            "traceFlags": "01",
+            "traceState": "vendor=value",
         })
         assert data["session_id"] == "sess-1"
         assert data["request_model"] == "claude-3-7-sonnet"
@@ -170,6 +175,11 @@ class TestNormalizeInputData:
         assert data["cache_read_input_tokens"] == 2
         assert data["agent_name"] == "planner"
         assert data["hook_event_type"] == "PreToolUse"
+        assert data["trace_id"] == "a" * 32
+        assert data["span_id"] == "b" * 16
+        assert data["parent_span_id"] == "c" * 16
+        assert data["trace_flags"] == "01"
+        assert data["tracestate"] == "vendor=value"
 
     def test_returns_original_dict_when_no_aliases_are_needed(self):
         data = {"session_id": "sess-1"}
@@ -323,6 +333,18 @@ class TestDetectAgentEngine:
 
     def test_returns_none_without_engine_signal(self):
         assert otel_hook._detect_agent_engine({"session_id": "sess-1"}) is None
+
+    def test_detects_gemini_from_corroborated_semantic_fields(self):
+        assert otel_hook._detect_agent_engine({
+            "gen_ai.client.name": "gemini",
+            "service.name": "gemini-cli",
+        }) == "gemini"
+
+    def test_ignores_single_semantic_field_without_corroboration(self):
+        assert otel_hook._detect_agent_engine({
+            "gen_ai.system": "vscode",
+            "session_id": "sess-1",
+        }) is None
 
 
 # ── OpenCode plugin payload handling ──────────────────────────────────────
@@ -758,6 +780,34 @@ class TestGenAISemconv:
         assert attrs["gen_ai.provider.name"] == "openai"
         assert attrs["gen_ai.system"] == "cursor"
 
+    def test_nested_agent_engine_becomes_genai_system(self):
+        span = mock.MagicMock()
+
+        otel_hook._apply_genai_semconv(
+            span,
+            "SubagentStop",
+            {"gen_ai.client.name": "gemini", "service.name": "gemini-cli"},
+            "claude",
+            session_ctx={"agent_engine": "gemini"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.system"] == "gemini"
+
+    def test_single_semantic_field_does_not_change_genai_system(self):
+        span = mock.MagicMock()
+
+        otel_hook._apply_genai_semconv(
+            span,
+            "UserPromptSubmit",
+            {"gen_ai.system": "vscode"},
+            "cursor",
+            session_ctx={},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.system"] == "cursor"
+
 
 class TestClientIdentityAttributes:
     @staticmethod
@@ -774,7 +824,8 @@ class TestClientIdentityAttributes:
         otel_hook._set_client_identity_attributes(span, "cursor", data={"session_id": "sess-1"})
 
         attrs = self._attrs(span)
-        assert attrs["gen_ai.client.name"] == "cursor"
+        assert attrs["gen_ai.client.name"] == "claude"
+        assert attrs["gen_ai.client.wrapper"] == "cursor"
         assert attrs["gen_ai.client.agent_engine"] == "claude"
 
     def test_omits_agent_engine_when_same_as_outer_ide(self):
@@ -784,6 +835,30 @@ class TestClientIdentityAttributes:
 
         attrs = self._attrs(span)
         assert attrs["gen_ai.client.name"] == "claude"
+        assert "gen_ai.client.agent_engine" not in attrs
+
+    def test_promotes_gemini_over_outer_claude(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"gen_ai.client.name": "gemini", "service.name": "gemini-cli"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "gemini"
+        assert attrs["gen_ai.client.wrapper"] == "claude"
+        assert attrs["gen_ai.client.agent_engine"] == "gemini"
+
+    def test_preserves_outer_agent_when_single_semantic_field_disagrees(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(span, "cursor", data={"gen_ai.system": "vscode"})
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "cursor"
+        assert "gen_ai.client.wrapper" not in attrs
         assert "gen_ai.client.agent_engine" not in attrs
 
 
@@ -920,6 +995,118 @@ class TestSessionContext:
     def test_load_missing_returns_none(self):
         assert otel_hook._load_session_context(None) is None
         assert otel_hook._load_session_context("nonexistent-session") is None
+
+    def test_create_uses_upstream_trace_context_when_present(self, tmp_path):
+        with mock.patch.object(otel_hook, "_SESSION_DIR", str(tmp_path)):
+            with mock.patch.object(otel_hook, "_LOCK_DIR", str(tmp_path / "locks")):
+                ctx = otel_hook._create_session_context(
+                    "sess-upstream",
+                    {"traceparent": f"00-{'a' * 32}-{'b' * 16}-00", "tracestate": "vendor=value"},
+                    "cursor",
+                )
+                assert ctx["trace_id"] == "a" * 32
+                assert ctx["upstream_parent_span_id"] == "b" * 16
+                assert ctx["trace_flags"] == "00"
+                assert ctx["tracestate"] == "vendor=value"
+                assert ctx["context_origin"] == "upstream"
+
+    def test_binds_existing_synthetic_session_to_first_upstream_context(self, tmp_path):
+        with mock.patch.object(otel_hook, "_SESSION_DIR", str(tmp_path)):
+            with mock.patch.object(otel_hook, "_LOCK_DIR", str(tmp_path / "locks")):
+                ctx = otel_hook._create_session_context("sess-bind", {}, "cursor")
+                assert ctx["context_origin"] == "synthetic"
+                updated = otel_hook._maybe_bind_session_to_upstream_context(
+                    "sess-bind",
+                    ctx,
+                    {"trace_id": "d" * 32, "span_id": "e" * 16},
+                )
+                assert updated["trace_id"] == "d" * 32
+                assert updated["upstream_parent_span_id"] == "e" * 16
+                assert updated["context_origin"] == "upstream"
+                loaded = otel_hook._load_session_context("sess-bind")
+                assert loaded["trace_id"] == "d" * 32
+                assert loaded["upstream_parent_span_id"] == "e" * 16
+
+
+class TestUpstreamTraceContext:
+    def test_parses_traceparent_payload(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "traceparent": f"00-{'1' * 32}-{'2' * 16}-00",
+            "tracestate": "vendor=value",
+        })
+        assert ctx == {
+            "trace_id": "1" * 32,
+            "parent_span_id": "2" * 16,
+            "trace_flags": "00",
+            "tracestate": "vendor=value",
+        }
+
+    def test_explicit_ids_prefer_current_span_id_as_parent(self):
+        ctx = otel_hook._resolve_upstream_trace_context({
+            "trace_id": "3" * 32,
+            "span_id": "4" * 16,
+            "parent_span_id": "5" * 16,
+            "trace_flags": "01",
+        })
+        assert ctx == {
+            "trace_id": "3" * 32,
+            "parent_span_id": "4" * 16,
+            "trace_flags": "01",
+        }
+
+    def test_reads_trace_context_from_env(self, monkeypatch):
+        monkeypatch.setenv("TRACEPARENT", f"00-{'6' * 32}-{'7' * 16}-01")
+        monkeypatch.setenv("TRACESTATE", "foo=bar")
+        ctx = otel_hook._resolve_upstream_trace_context({})
+        assert ctx == {
+            "trace_id": "6" * 32,
+            "parent_span_id": "7" * 16,
+            "trace_flags": "01",
+            "tracestate": "foo=bar",
+        }
+
+    def test_rejects_zero_trace_context(self):
+        assert otel_hook._resolve_upstream_trace_context({
+            "trace_id": "0" * 32,
+            "span_id": "1" * 16,
+        }) is None
+
+
+class TestTraceContextSelection:
+    def test_session_trace_context_prefers_upstream_parent(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            otel_hook,
+            "_make_trace_context",
+            lambda tid, sid, flags="01", tracestate=None: calls.append((tid, sid, flags, tracestate)) or "ctx",
+        )
+        session_ctx = {
+            "trace_id": "8" * 32,
+            "upstream_parent_span_id": "9" * 16,
+            "phantom_parent_id": "a" * 16,
+            "trace_flags": "00",
+            "tracestate": "vendor=value",
+        }
+        assert otel_hook._session_trace_context(session_ctx) == "ctx"
+        assert calls == [("8" * 32, "9" * 16, "00", "vendor=value")]
+
+    def test_event_context_overrides_session_fallback(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(
+            otel_hook,
+            "_make_trace_context",
+            lambda tid, sid, flags="01", tracestate=None: calls.append((tid, sid, flags, tracestate)) or "ctx",
+        )
+        session_ctx = {
+            "trace_id": "b" * 32,
+            "upstream_parent_span_id": "c" * 16,
+            "phantom_parent_id": "d" * 16,
+        }
+        assert otel_hook._event_parent_trace_context(
+            {"trace_id": "e" * 32, "span_id": "f" * 16, "trace_flags": "00"},
+            session_ctx,
+        ) == "ctx"
+        assert calls == [("e" * 32, "f" * 16, "00", None)]
 
 
 # ── Generation advance ────────────────────────────────────────────────────
@@ -1061,7 +1248,7 @@ class TestMainFlow:
         """Main outputs legacy continue response by default."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO('{"hook_event_name":"stop"}'))
         # Prevent actual tracing init
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1093,7 +1280,7 @@ class TestMainFlow:
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: True)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: True)
         monkeypatch.setattr(otel_hook, "_flush_stale_sessions", lambda tracer: None)
         monkeypatch.setattr(otel_hook, "_force_flush_provider", lambda **kw: None)
         mock_span_cm = mock.MagicMock()
@@ -1115,7 +1302,7 @@ class TestMainFlow:
     def test_empty_input(self, monkeypatch):
         """Empty stdin should not crash."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO(""))
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1128,7 +1315,7 @@ class TestMainFlow:
     def test_malformed_json(self, monkeypatch):
         """Malformed JSON should not crash."""
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO("{bad json"))
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: False)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
         monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
@@ -1148,7 +1335,7 @@ class TestMainFlow:
         appended = []
         monkeypatch.setattr(otel_hook, "_append_batch_event", lambda key, evt, data: appended.append((key, evt)))
         called = {"init": 0}
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide: called.__setitem__("init", called["init"] + 1) or True)
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: called.__setitem__("init", called["init"] + 1) or True)
         captured = []
         monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
         result = otel_hook.main()


### PR DESCRIPTION
## Summary
- import upstream trace context from payload/env fields and persist it across session batching
- normalize nested agent attribution so the inner engine becomes canonical while preserving wrapper identity
- add regression coverage to prevent accidental reclassification from a single semantic field

## Validation
- python -m pytest -q
- python -m ruff check .