### PR TITLE
Fix passive Codex hook responses and bump version to 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.3 (unreleased)
+
+### Fixed
+- Made passive Codex hooks stay silent for non-`Stop` events like `PostToolUse`, while keeping `Stop` on the minimal valid JSON response and suppressing the custom `local_spans` field in Codex stdout responses
+
 ## 0.13.2 (2026-05-18)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Every hook event — prompt submissions, tool calls, shell commands, MCP interac
 
 ## How It Works
 
-The hook is a lightweight Python command that your IDE invokes on every agent event. The IDE pipes a JSON payload to stdin, the hook processes it, emits OpenTelemetry spans and logs, and returns the runner-compatible success response on stdout so the IDE proceeds normally. For most events that is `{"continue": true}`; Codex `SessionStart` and `UserPromptSubmit` intentionally exit with no stdout because Codex treats passive JSON there as structured hook output. No sidecar, no daemon — just a command your IDE calls.
+The hook is a lightweight Python command that your IDE invokes on every agent event. The IDE pipes a JSON payload to stdin, the hook processes it, emits OpenTelemetry spans and logs, and returns the runner-compatible success response on stdout so the IDE proceeds normally. For most events that is `{"continue": true}`; Codex uses event-specific response contracts, so passive Codex hooks stay silent except for `Stop`, which still returns JSON. No sidecar, no daemon — just a command your IDE calls.
 
 ```
 IDE Event → stdin (JSON) → otel-hook → OpenTelemetry SDK → OTLP Backend
@@ -465,7 +465,7 @@ The hook writes the response expected by the current IDE/client.
 {"continue": true}
 ```
 
-- Codex `SessionStart` and `UserPromptSubmit`:
+- Codex passive hooks (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`):
 
 ```text
 <no stdout>
@@ -477,7 +477,7 @@ The hook writes the response expected by the current IDE/client.
 {"continue": true, "local_spans": true}
 ```
 
-For the stdout response field, `local_spans` uses `IDE_OTEL_LOCAL_SPANS` when set; otherwise internal behavior falls back to `IDE_OTEL_BATCH_ON_STOP`. Codex `SessionStart` and `UserPromptSubmit` skip stdout entirely because those events accept exit-0/no-output success but reject the generic passive JSON envelope.
+For the stdout response field, `local_spans` uses `IDE_OTEL_LOCAL_SPANS` when set; otherwise internal behavior falls back to `IDE_OTEL_BATCH_ON_STOP`. Codex responses are adapter-managed: passive non-`Stop` events skip stdout entirely, and Codex responses do not include the custom `local_spans` field because Codex validates event-specific JSON schemas.
 
 ## Local Trace Files (Agent-Friendly)
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -2189,7 +2189,7 @@ class HookResponseAdapter:
 class CodexHookResponseAdapter(HookResponseAdapter):
     """Codex has event-specific stdout contracts that differ from the default envelope."""
 
-    _PASSIVE_SILENT_EVENTS = frozenset({"SessionStart", "UserPromptSubmit"})
+    _STOP_EVENT = "Stop"
 
     def build_payload(
         self,
@@ -2197,9 +2197,13 @@ class CodexHookResponseAdapter(HookResponseAdapter):
         data: dict,
         governance: Optional[GovernanceResponse] = None,
     ) -> Optional[dict]:
-        if governance is None and event_name in self._PASSIVE_SILENT_EVENTS:
+        if governance is None:
+            if event_name == self._STOP_EVENT:
+                return {"continue": True}
             return None
-        return super().build_payload(event_name, data, governance)
+
+        base_payload = {"continue": True} if event_name == self._STOP_EVENT else {}
+        return self._merge_governance(base_payload, governance)
 
 
 _DEFAULT_HOOK_RESPONSE_ADAPTER = HookResponseAdapter()

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -2189,7 +2189,10 @@ class HookResponseAdapter:
 class CodexHookResponseAdapter(HookResponseAdapter):
     """Codex has event-specific stdout contracts that differ from the default envelope."""
 
-    _STOP_EVENT = "Stop"
+    # Keep these derived from the same lifecycle constants main() uses so Codex
+    # stdout behavior stays aligned if shared event sets change.
+    _JSON_RESPONSE_EVENTS = frozenset(_GENERATION_END_EVENTS.intersection(_CODEX_EVENTS))
+    _SILENT_SUCCESS_EVENTS = frozenset(set(_CODEX_EVENTS).difference(_JSON_RESPONSE_EVENTS))
 
     def build_payload(
         self,
@@ -2198,11 +2201,13 @@ class CodexHookResponseAdapter(HookResponseAdapter):
         governance: Optional[GovernanceResponse] = None,
     ) -> Optional[dict]:
         if governance is None:
-            if event_name == self._STOP_EVENT:
+            if event_name in self._JSON_RESPONSE_EVENTS:
                 return {"continue": True}
-            return None
+            if event_name in self._SILENT_SUCCESS_EVENTS:
+                return None
+            return super().build_payload(event_name, data, governance)
 
-        base_payload = {"continue": True} if event_name == self._STOP_EVENT else {}
+        base_payload = {"continue": True} if event_name in self._JSON_RESPONSE_EVENTS else {}
         return self._merge_governance(base_payload, governance)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentelemetry-hooks"
-version = "0.13.2"
+version = "0.13.3"
 description = "OpenTelemetry integration for AI coding agents (Codex, Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1311,6 +1311,23 @@ class TestMainFlow:
         assert result == 0
         assert captured == []
 
+    def test_codex_post_tool_use_suppresses_stdout(self, monkeypatch):
+        monkeypatch.setattr(
+            "sys.stdin",
+            __import__("io").StringIO('{"hook_event_name":"PostToolUse","session_id":"s1","source_app":"Codex","tool_name":"Bash"}'),
+        )
+        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
+        monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
+        monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
+        monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
+        captured = []
+        monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
+
+        result = otel_hook.main()
+
+        assert result == 0
+        assert captured == []
+
     def test_codex_stop_keeps_json_stdout(self, monkeypatch):
         monkeypatch.setattr("sys.stdin", __import__("io").StringIO('{"hook_event_name":"Stop","session_id":"s1","source_app":"Codex"}'))
         monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
@@ -1346,13 +1363,17 @@ class TestMainFlow:
         )
 
         assert json.loads(response) == {
-            "continue": True,
             "systemMessage": "workspace policy loaded",
             "hookSpecificOutput": {
                 "hookEventName": "SessionStart",
                 "additionalContext": "Load repository guardrails before editing.",
             },
         }
+
+    def test_codex_stop_ignores_local_spans_flag(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_LOCAL_SPANS", "true")
+        response = otel_hook._stdout_response("Stop", "codex", {"session_id": "s1"})
+        assert json.loads(response) == {"continue": True}
 
     def test_continue_response_opt_in_local_spans_flag(self, monkeypatch):
         monkeypatch.setenv("IDE_OTEL_LOCAL_SPANS", "true")

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1277,45 +1277,18 @@ class TestMainFlow:
         assert result == 0
         assert json.loads(captured[0]) == {"continue": True}
 
-    def test_codex_session_start_suppresses_stdout(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.stdin",
-            __import__("io").StringIO('{"hook_event_name":"SessionStart","session_id":"s1","source_app":"Codex"}'),
-        )
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
-        monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
-        monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
-        monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
-        captured = []
-        monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
-
-        result = otel_hook.main()
-
-        assert result == 0
-        assert captured == []
-
-    def test_codex_user_prompt_submit_suppresses_stdout(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.stdin",
-            __import__("io").StringIO('{"hook_event_name":"UserPromptSubmit","session_id":"s1","source_app":"Codex"}'),
-        )
-        monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
-        monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
-        monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)
-        monkeypatch.setattr(otel_hook, "_load_config", lambda: {})
-        captured = []
-        monkeypatch.setattr("builtins.print", lambda s: captured.append(s))
-
-        result = otel_hook.main()
-
-        assert result == 0
-        assert captured == []
-
-    def test_codex_post_tool_use_suppresses_stdout(self, monkeypatch):
-        monkeypatch.setattr(
-            "sys.stdin",
-            __import__("io").StringIO('{"hook_event_name":"PostToolUse","session_id":"s1","source_app":"Codex","tool_name":"Bash"}'),
-        )
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            '{"hook_event_name":"SessionStart","session_id":"s1","source_app":"Codex"}',
+            '{"hook_event_name":"UserPromptSubmit","session_id":"s1","source_app":"Codex"}',
+            '{"hook_event_name":"PreToolUse","session_id":"s1","source_app":"Codex","tool_name":"Bash"}',
+            '{"hook_event_name":"PermissionRequest","session_id":"s1","source_app":"Codex","tool_name":"Bash"}',
+            '{"hook_event_name":"PostToolUse","session_id":"s1","source_app":"Codex","tool_name":"Bash"}',
+        ],
+    )
+    def test_codex_passive_events_suppress_stdout(self, monkeypatch, payload):
+        monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
         monkeypatch.setattr(otel_hook, "_init_tracing", lambda ide, **kwargs: False)
         monkeypatch.setattr(otel_hook, "_configure_logging", lambda: None)
         monkeypatch.setattr(otel_hook, "_cleanup_state", lambda: None)


### PR DESCRIPTION
## Summary
- fix passive Codex hook responses so non-`Stop` events stay silent and `Stop` keeps the minimal valid JSON envelope
- suppress the custom `local_spans` field in Codex stdout responses
- bump the checked-in project version to `0.13.3` and add the unreleased changelog entry needed for the next release

## Why
`0.13.2` is already released. This branch needs the next patch version checked in so the manual release workflow can cut `v0.13.3` cleanly after merge.