### PR TITLE
Fix Cursor attribution leakage and bump version to 0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.4 (unreleased)
+
+### Fixed
+- Preserved native Cursor client attribution for Cursor-style payloads when leaked Claude-specific hints would otherwise misclassify the event, while still recording any distinct wrapper via `gen_ai.client.wrapper`
+
 ## 0.13.3 (2026-05-19)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -790,7 +790,7 @@ The hook auto-detects which IDE is calling it:
 
 Detection order is: (1) parent process tree, (2) explicit `IDE_OTEL_IDE_NAME`, (3) self-reported payload fields, then (4) heuristics. `setup.sh` now relies on process discovery for generated Cursor, Copilot, and Claude configs, while the env var remains available as an escape hatch for generic runners and debugging.
 
-The hook still detects the outer wrapper IDE/process, but the emitted canonical client identity now prefers a distinct inner engine when one is present (for example Gemini running under Claude Code). In that case, spans/resources use the inner engine for `gen_ai.client.name` and `gen_ai.system`, keep `gen_ai.client.agent_engine` for compatibility, and record the wrapper as `gen_ai.client.wrapper`. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
+The hook still detects the outer wrapper IDE/process, but the emitted canonical client identity now prefers a distinct inner engine when one is present (for example Gemini running under Claude Code). In that case, spans/resources use the inner engine for `gen_ai.client.name` and `gen_ai.system`, keep `gen_ai.client.agent_engine` for compatibility, and record the wrapper as `gen_ai.client.wrapper`. Native payload signals beat leaked wrapper-only env hints, so Cursor-specific fields such as `conversation_id` / `generation_id` still emit `gen_ai.client.name=cursor` when stale Claude-specific hints are present. When the hook can infer a provider from the payload, it also sets `gen_ai.provider.name` as the canonical provider attribute (v1.37+).
 
 ## File Structure
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -679,29 +679,8 @@ def _detect_client_version(data: dict, ide: str) -> Optional[str]:
     return None
 
 
-def _detect_agent_engine(data: dict) -> Optional[str]:
-    """Detect an inner agent engine without consulting IDE_OTEL_IDE_NAME."""
-    explicit = _normalize_ide_name(_first_present(
-        data,
-        (
-            "agent_engine",
-            "agentEngine",
-            "engine",
-            "engine_name",
-        ),
-    ))
-    if explicit:
-        return explicit
-
-    if os.getenv("CLAUDE_CODE_ENTRYPOINT"):
-        return "claude"
-
-    if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
-        return "claude"
-
-    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
-        return "codex"
-
+def _detect_payload_client_name(data: dict, include_session_fallback: bool = False) -> Optional[str]:
+    """Infer client identity from payload fields only, without wrapper env hints."""
     reported = _normalize_ide_name(_first_present(data, ("ide_name", "ide", "client", "source_app")))
     if reported:
         return reported
@@ -719,8 +698,61 @@ def _detect_agent_engine(data: dict) -> Optional[str]:
     if len(corroborated) == 1:
         return corroborated[0]
 
+    if data.get("conversation_id") or data.get("generation_id"):
+        return "cursor"
+
+    if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
+        return "claude"
+
+    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
+        return "codex"
+
     raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
     if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
+        return "claude"
+
+    cursor_indicators = ("composer_mode", "agent_type", "cwd", "workspace", "workspace_path")
+    if any(data.get(key) for key in cursor_indicators):
+        return "cursor"
+
+    try:
+        cwd = data.get("cwd") or os.getcwd()
+        if ".cursor" in cwd or os.path.exists(os.path.join(cwd, ".cursor")):
+            return "cursor"
+    except Exception:
+        pass
+
+    if include_session_fallback and data.get("session_id"):
+        return "copilot"
+
+    return None
+
+
+def _detect_agent_engine(data: dict) -> Optional[str]:
+    """Detect an inner agent engine without consulting IDE_OTEL_IDE_NAME."""
+    explicit = _normalize_ide_name(_first_present(
+        data,
+        (
+            "agent_engine",
+            "agentEngine",
+            "engine",
+            "engine_name",
+        ),
+    ))
+    if explicit:
+        return explicit
+
+    if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
+        return "claude"
+
+    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
+        return "codex"
+
+    payload_client = _detect_payload_client_name(data, include_session_fallback=False)
+    if payload_client:
+        return payload_client
+
+    if os.getenv("CLAUDE_CODE_ENTRYPOINT"):
         return "claude"
 
     return None
@@ -1930,38 +1962,13 @@ def _detect_ide(data: dict) -> str:
         return override
 
     # Level 3: Self-reported payload fields.
-    reported = _normalize_ide_name(_first_present(data, ("ide_name", "ide", "client", "source_app")))
-    if reported:
-        return reported
+    payload_client = _detect_payload_client_name(data, include_session_fallback=False)
+    if payload_client:
+        return payload_client
 
     # Level 4: Heuristic fallback — Claude-specific signals.
     if os.getenv("CLAUDE_CODE_ENTRYPOINT"):
         return "claude"
-
-    if data.get("transcript_path") or data.get("permission_mode") or data.get("notification_type"):
-        return "claude"
-
-    if data.get("turn_id") or data.get("last_assistant_message") is not None or data.get("tool_response") is not None:
-        return "codex"
-
-    raw_event = _first_present(data, ("hook_event_name", "hook_event_type", "event"))
-    if isinstance(raw_event, str) and raw_event and raw_event[0].isupper():
-        return "claude"
-
-    # Level 4: Cursor-specific fields.
-    if data.get("conversation_id") or data.get("generation_id"):
-        return "cursor"
-
-    cursor_indicators = ("composer_mode", "agent_type", "cwd", "workspace", "workspace_path")
-    if any(data.get(key) for key in cursor_indicators):
-        return "cursor"
-
-    try:
-        cwd = data.get("cwd") or os.getcwd()
-        if ".cursor" in cwd or os.path.exists(os.path.join(cwd, ".cursor")):
-            return "cursor"
-    except Exception:
-        pass
 
     # Level 5: Copilot (session_id without other indicators).
     if data.get("session_id"):

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -719,8 +719,8 @@ def _detect_payload_client_name(data: dict, include_session_fallback: bool = Fal
         cwd = data.get("cwd") or os.getcwd()
         if ".cursor" in cwd or os.path.exists(os.path.join(cwd, ".cursor")):
             return "cursor"
-    except Exception:
-        pass
+    except Exception as exc:
+        logging.debug("Failed cursor cwd heuristic during payload client detection: %s", exc)
 
     if include_session_fallback and data.get("session_id"):
         return "copilot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentelemetry-hooks"
-version = "0.13.3"
+version = "0.13.4"
 description = "OpenTelemetry integration for AI coding agents (Codex, Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -327,9 +327,17 @@ class TestDetectAgentEngine:
         monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "1")
         assert otel_hook._detect_agent_engine({"session_id": "sess-1"}) == "claude"
 
-    def test_detects_claude_when_outer_cursor_ide_present(self, monkeypatch):
+    def test_cursor_payload_beats_leaked_claude_env(self, monkeypatch):
         monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "1")
-        assert otel_hook._detect_agent_engine({"client": "Cursor IDE", "session_id": "sess-1"}) == "claude"
+        assert otel_hook._detect_agent_engine({"client": "Cursor IDE", "session_id": "sess-1"}) == "cursor"
+
+    def test_detects_claude_from_payload_when_outer_cursor_fields_exist(self, monkeypatch):
+        monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "1")
+        assert otel_hook._detect_agent_engine({
+            "client": "Cursor IDE",
+            "session_id": "sess-1",
+            "transcript_path": "/tmp/transcript.jsonl",
+        }) == "claude"
 
     def test_returns_none_without_engine_signal(self):
         assert otel_hook._detect_agent_engine({"session_id": "sess-1"}) is None
@@ -821,12 +829,30 @@ class TestClientIdentityAttributes:
         monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "1")
         span = mock.MagicMock()
 
-        otel_hook._set_client_identity_attributes(span, "cursor", data={"session_id": "sess-1"})
+        otel_hook._set_client_identity_attributes(
+            span,
+            "cursor",
+            data={"session_id": "sess-1", "transcript_path": "/tmp/transcript.jsonl"},
+        )
 
         attrs = self._attrs(span)
         assert attrs["gen_ai.client.name"] == "claude"
         assert attrs["gen_ai.client.wrapper"] == "cursor"
         assert attrs["gen_ai.client.agent_engine"] == "claude"
+
+    def test_promotes_cursor_over_misattributed_outer_ide_from_native_payload(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"conversation_id": "conv-1", "generation_id": "gen-1"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "cursor"
+        assert attrs["gen_ai.client.wrapper"] == "claude"
+        assert attrs["gen_ai.client.agent_engine"] == "cursor"
 
     def test_omits_agent_engine_when_same_as_outer_ide(self):
         span = mock.MagicMock()


### PR DESCRIPTION
## Summary
- preserve native Cursor client attribution for Cursor-style payloads when leaked Claude-specific hints would otherwise misclassify the event
- keep distinct wrapper context on emitted telemetry via `gen_ai.client.wrapper` and add regression coverage for the attribution path
- bump the package version to 0.13.4 and add the changelog entry for release prep

## Validation
- poetry run pytest -q
- poetry run ruff check .