### PR TITLE
Capture fallback failure reasons for tool events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.13.6 (2026-05-26)
+
+### Fixed
+- Captured fallback failure reasons for tool events when payloads omit explicit `error` text by deriving from exit codes, status/reason fields, and nested metadata/tool-response fields, and propagated these reasons on `PostToolUse` spans via `gen_ai.client.error`.
+
 ## 0.13.5 (2026-05-25)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pip install opentelemetry-hooks
 To pin a specific version or install directly from a tag:
 
 ```bash
-pipx install git+https://github.com/o11y-dev/opentelemetry-hooks.git@v0.13.5
+pipx install git+https://github.com/o11y-dev/opentelemetry-hooks.git@v0.13.6
 ```
 
 Or install from a pre-built wheel from the [Releases](https://github.com/o11y-dev/opentelemetry-hooks/releases) page:

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -610,9 +610,6 @@ def _synthesize_failure_reason(data: dict) -> Optional[str]:
         text = str(reason).strip()
         if text:
             return f"{status}: {text}" if status in _FAILURE_STATUSES else text
-    if status in _FAILURE_STATUSES:
-        return f"status={status}"
-
     for container in (data.get("metadata"), data.get("tool_response")):
         if isinstance(container, dict):
             nested = _first_present(container, ("error", "reason", "failure_reason", "message", "stderr", "details"))
@@ -620,6 +617,8 @@ def _synthesize_failure_reason(data: dict) -> Optional[str]:
                 text = str(nested).strip()
                 if text:
                     return text
+    if status in _FAILURE_STATUSES:
+        return f"status={status}"
     return None
 
 

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -462,7 +462,7 @@ _EVENT_ATTR_MAP = {
     },
     "SessionEnd": {"status": "gen_ai.client.status", "reason": "gen_ai.client.session_end_reason"},
     "PreToolUse": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id"},
-    "PostToolUse": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "duration_ms": "gen_ai.client.duration_ms"},
+    "PostToolUse": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "duration_ms": "gen_ai.client.duration_ms", "error": "gen_ai.client.error"},
     "PostToolUseFailure": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "error": "gen_ai.client.error", "is_interrupt": "gen_ai.client.is_interrupt"},
     "PermissionRequest": {"tool_name": "gen_ai.client.tool_name", "tool_id": "gen_ai.client.tool_id", "tool_use_id": "gen_ai.client.tool_use_id", "turn_id": "gen_ai.client.turn_id"},
     "SubagentStart": {"subagent_type": "gen_ai.client.subagent_type", "subagent_task": "gen_ai.client.subagent_task", "agent_id": "gen_ai.client.agent_id", "agent_type": "gen_ai.client.agent_type"},
@@ -559,6 +559,82 @@ def _lower_or_none(value: Optional[str]) -> Optional[str]:
         return None
     lowered = value.strip().lower()
     return lowered or None
+
+
+_FAILURE_STATUSES = frozenset({
+    "error", "failed", "failure", "cancelled", "canceled",
+    "timeout", "timed_out", "interrupted", "denied",
+})
+
+
+def _extract_exit_code(data: dict) -> Optional[int]:
+    for value in (data.get("exit_code"),):
+        code = _int_or_none(value)
+        if code is not None:
+            return code
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        code = _int_or_none(metadata.get("exit"))
+        if code is not None:
+            return code
+    return None
+
+
+def _is_failure_status(value) -> bool:
+    status = _lower_or_none(value)
+    return status in _FAILURE_STATUSES if status else False
+
+
+def _event_indicates_failure(event_name: str, data: dict) -> bool:
+    if event_name in {"PostToolUseFailure", "ErrorOccurred"}:
+        return True
+    exit_code = _extract_exit_code(data)
+    if exit_code is not None and exit_code != 0:
+        return True
+    if _is_failure_status(_first_present(data, ("status", "state", "result"))):
+        return True
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict) and _is_failure_status(_first_present(metadata, ("status", "state", "result"))):
+        return True
+    return False
+
+
+def _synthesize_failure_reason(data: dict) -> Optional[str]:
+    exit_code = _extract_exit_code(data)
+    if exit_code is not None and exit_code != 0:
+        return f"exit {exit_code}"
+
+    status = _lower_or_none(_first_present(data, ("status", "state", "result")))
+    reason = _first_present(data, ("reason", "failure_reason", "stop_reason"))
+    if reason is not None:
+        text = str(reason).strip()
+        if text:
+            return f"{status}: {text}" if status in _FAILURE_STATUSES else text
+    if status in _FAILURE_STATUSES:
+        return f"status={status}"
+
+    for container in (data.get("metadata"), data.get("tool_response")):
+        if isinstance(container, dict):
+            nested = _first_present(container, ("error", "reason", "failure_reason", "message", "stderr", "details"))
+            if nested is not None:
+                text = str(nested).strip()
+                if text:
+                    return text
+    return None
+
+
+def _enrich_failure_details(event_name: str, data: dict) -> dict:
+    if not isinstance(data, dict):
+        return data
+    error = data.get("error")
+    if error is not None and str(error).strip():
+        return data
+    if not _event_indicates_failure(event_name, data):
+        return data
+    synthesized = _synthesize_failure_reason(data)
+    if synthesized:
+        data["error"] = synthesized
+    return data
 
 
 def _normalize_genai_output_type(value) -> Optional[str]:
@@ -2887,6 +2963,7 @@ def main() -> int:
     data = _normalize_input_data(input_data)
     raw_event = _get_event_name(data)
     event_name = _normalize_event(raw_event)
+    data = _enrich_failure_details(event_name, data)
     ide = _detect_ide(data)
     sk = _session_key(data)
     session_ctx = _load_session_context(sk)

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -1444,6 +1444,7 @@ def _init_sdk_tracer_provider(resource_attrs: dict, disable_batch: bool) -> bool
         except ImportError as exc:
             _LOGGER.warning("gRPC exporter unavailable: %s — falling back to http/protobuf", exc)
             protocol = "http/protobuf"
+            endpoint = _http_fallback_endpoint(endpoint)
 
     if exporter is None:
         try:
@@ -1480,6 +1481,14 @@ def _derive_logs_endpoint() -> Optional[str]:
     return base or None
 
 
+def _http_fallback_endpoint(endpoint: Optional[str]) -> Optional[str]:
+    if not endpoint:
+        return endpoint
+    if endpoint in {"http://localhost:4317", "http://127.0.0.1:4317"}:
+        return endpoint.rsplit(":", 1)[0] + ":4318"
+    return endpoint
+
+
 def _init_sdk_logger_provider(resource_attrs: dict, disable_batch: bool) -> bool:
     """Configure the OTel SDK LoggerProvider with OTLP log exporter."""
     global _OTEL_LOG_HANDLER, _LOGS_INITIALIZED
@@ -1508,6 +1517,7 @@ def _init_sdk_logger_provider(resource_attrs: dict, disable_batch: bool) -> bool
         except ImportError as exc:
             _LOGGER.warning("gRPC log exporter unavailable: %s — falling back to http/protobuf", exc)
             protocol = "http/protobuf"
+            endpoint = _http_fallback_endpoint(endpoint)
 
     if exporter is None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opentelemetry-hooks"
-version = "0.13.5"
+version = "0.13.6"
 description = "OpenTelemetry integration for AI coding agents (Codex, Cursor IDE/CLI, GitHub Copilot, Claude Code, Gemini CLI, Antigravity, OpenCode-compatible runners)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1836,6 +1836,11 @@ class TestFailureReasonEnrichment:
         otel_hook._enrich_failure_details("PostToolUse", data)
         assert data["error"] == "tool crashed"
 
+    def test_prefers_nested_message_over_failure_status_fallback(self):
+        data = {"status": "failed", "metadata": {"message": "tool crashed"}}
+        otel_hook._enrich_failure_details("PostToolUse", data)
+        assert data["error"] == "tool crashed"
+
     def test_skips_successful_events(self):
         data = {"status": "ok", "exit_code": 0}
         otel_hook._enrich_failure_details("PostToolUse", data)

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -929,6 +929,11 @@ class TestDeriveLogsEndpoint:
             os.environ.pop("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", None)
             assert otel_hook._derive_logs_endpoint() == "http://localhost:4317"
 
+    def test_http_fallback_endpoint_uses_local_http_port(self):
+        assert otel_hook._http_fallback_endpoint("http://localhost:4317") == "http://localhost:4318"
+        assert otel_hook._http_fallback_endpoint("http://127.0.0.1:4317") == "http://127.0.0.1:4318"
+        assert otel_hook._http_fallback_endpoint("https://collector.example:4317") == "https://collector.example:4317"
+
 
 # ── Batch buffer I/O ─────────────────────────────────────────────────────
 

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -1810,6 +1810,40 @@ class TestSetCodexToolAttrs:
         assert "PermissionRequest" in otel_hook._TOOL_EVENTS
 
 
+class TestFailureReasonEnrichment:
+    def test_preserves_explicit_error(self):
+        data = {"error": "permission denied", "exit_code": 1}
+        otel_hook._enrich_failure_details("PostToolUseFailure", data)
+        assert data["error"] == "permission denied"
+
+    def test_synthesizes_from_exit_code(self):
+        data = {"exit_code": 127}
+        otel_hook._enrich_failure_details("PostToolUseFailure", data)
+        assert data["error"] == "exit 127"
+
+    def test_synthesizes_from_failure_status_and_reason(self):
+        data = {"status": "failed", "reason": "command timed out"}
+        otel_hook._enrich_failure_details("PostToolUse", data)
+        assert data["error"] == "failed: command timed out"
+
+    def test_synthesizes_from_nested_metadata(self):
+        data = {"metadata": {"status": "failed", "message": "tool crashed"}}
+        otel_hook._enrich_failure_details("PostToolUse", data)
+        assert data["error"] == "tool crashed"
+
+    def test_skips_successful_events(self):
+        data = {"status": "ok", "exit_code": 0}
+        otel_hook._enrich_failure_details("PostToolUse", data)
+        assert "error" not in data
+
+    def test_populate_span_sets_error_for_failed_post_tool_use(self):
+        span = _FakeSpan()
+        data = {"tool_name": "bash", "tool_id": "call-1", "exit_code": 3}
+        otel_hook._enrich_failure_details("PostToolUse", data)
+        otel_hook._populate_span(span, "PostToolUse", data, "opencode")
+        assert span.attrs.get("gen_ai.client.error") == "exit 3"
+
+
 # ── New IDE name aliases ─────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Summary: synthesize missing tool failure reasons from exit code, status/reason, and nested metadata or tool response; enrich payloads early so logs and spans get consistent error text; map PostToolUse error to gen_ai.client.error; add tests for explicit error preservation and fallback synthesis paths. Why: some agent events fail without an explicit error string, producing generic failure chips instead of actionable reason text.