### PR TITLE
Add telemetry enrichment and rollout docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ gen_ai.client.session (root)
 
 - **Structured OTel Logs**: Emits trace-correlated log records for MCP calls, shell executions, and tool usage — with full I/O payloads, server output, and duration. Logs are exported via OTLP alongside spans.
 
+- **Repo-Aware Context**: Enriches telemetry with repository metadata such as `vcs.repository.name` when a git root can be resolved, and normalizes stored file-memory facts to repo-relative paths.
+
 - **Zero Setup**: Auto-provisions a Python virtual environment on first run. No manual install needed.
 
 - **Privacy Controls**: Built-in masking of emails, tokens, and usernames. Text capture is opt-in.
@@ -261,6 +263,17 @@ otel-hook
 The bundled Claude example and `setup.sh --claude` both invoke `otel-hook` directly without an IDE override env var.
 Claude Code is auto-detected from the parent process tree first; hook metadata such as `session_id`, `transcript_path`, `permission_mode`, and `notification_type` is used as a fallback. The camelCase alias handling is mainly for compatible third-party hook runners and mixed payload formats.
 
+##### Managed settings / enterprise rollout
+
+If your org already deploys Claude Code managed settings (server-managed, MDM/registry, or file-based `managed-settings.json`), keep hook registration and hook exporter config as two separate concerns:
+
+- Register `otel-hook` with the usual Claude `hooks` block (in project/user settings, or in managed settings if your org centrally manages hooks).
+- Configure this hook's exporter in `otel_config.json` or this repo's own MDM/registry settings — not in Claude Code's `env` block.
+
+Claude Code intentionally strips `OTEL_*` env vars from hook subprocesses, Bash, MCP servers, and language servers. `otel-hook` handles that safely by loading its own `otel_config.json`, then hook-side managed config, and only then filling any still-unset variables from the live process environment.
+
+See `examples/claude-managed-settings.example.json` for a minimal managed-settings snippet for Claude Code's own telemetry.
+
 #### Gemini CLI
 
 ```bash
@@ -278,6 +291,8 @@ bash setup.sh --gemini --global
 ```
 
 Gemini CLI emits model, tool, and agent lifecycle events. The hook maps `BeforeModel` / `AfterModel` to prompt and stop spans, `BeforeTool` / `AfterTool` to tool spans, and `BeforeAgent` / `AfterAgent` to subagent spans.
+
+> **Privacy note:** Avoid putting sensitive prompts directly on the command line with `gemini -p "..."`. Like most CLI arguments, the prompt can end up in shell history and may be visible in process lists while the command is running. Prefer interactive mode, stdin, or prompt files for sensitive input.
 
 #### Antigravity
 
@@ -388,6 +403,8 @@ Edit the hook config file. For pip/pipx installs this lives at `~/.local/share/o
 
 Then restart your agent or IDE.
 
+> **Why the config file matters:** `otel-hook` reads its own `otel_config.json` on every invocation, overlays this repo's MDM/registry policy, and only fills variables that are still unset from the live process environment. Explicit env vars still win, but the hook does not depend on parent-process `OTEL_*` inheritance. This is the safe path for Claude Code hooks, because Claude does not forward `OTEL_*` to hook subprocesses.
+
 ## Configuration Reference
 
 ### OTLP Exporter
@@ -409,6 +426,7 @@ Then restart your agent or IDE.
 | `IDE_OTEL_IDE_NAME` | Force the detected IDE name (`codex`, `cursor`, `copilot`, `claude`, `gemini`, `antigravity`, `opencode`) for generic hook runners; common labels like `OpenAI Codex`, `Codex CLI`, `GitHub Copilot`, `Claude Code`, `Cursor IDE` / `Cursor CLI`, `Gemini CLI`, `Anti Gravity`, `OpenCode`, and their `... CLI` / `... IDE` variants normalize automatically | auto-detect |
 | `IDE_OTEL_LOCAL_SPANS` | Save hook spans locally as JSONL files for agent analysis (`.state/local_spans/*.jsonl`) | unset |
 | `IDE_OTEL_CAPTURE_TEXT` | Include prompt/response text in spans | `false` |
+| `IDE_OTEL_CAPTURE_USER_IDENTITY` | Include opt-in `user.id` / `user.email` payload fields in spans and logs | `false` |
 | `IDE_OTEL_MASK_PROMPTS` | Redact emails, tokens, usernames from text | `false` |
 | `IDE_OTEL_TEXT_MAX_CHARS` | Max characters for captured text | `4000` |
 | `IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT` | Include tool input content in logs | `false` |
@@ -447,7 +465,7 @@ These settings have sensible defaults and typically don't need to be changed:
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `OTEL_EXPORTER_OTLP_INSECURE` | **gRPC only**: `true` for plaintext, `false` for TLS | `true` |
-| `IDE_OTEL_DISABLE_BATCH` | Disable OpenTelemetry batch span processor | `false` |
+| `IDE_OTEL_DISABLE_BATCH` | Disable OpenTelemetry batch processors and export immediately (useful for tests / short-lived debugging) | `false` |
 | `IDE_OTEL_STATE_TTL_SECONDS` | TTL for state files before cleanup | `86400` |
 | `IDE_OTEL_STATE_CLEANUP_INTERVAL_SECONDS` | Minimum interval between cleanup runs | `3600` |
 | `IDE_OTEL_STATE_LOCK_TIMEOUT_SECONDS` | Max time to wait for state file locks | `2` |
@@ -809,6 +827,7 @@ The hook still detects the outer wrapper IDE/process, but the emitted canonical 
         │   ├── cursor-hooks.example.json       # Minimal Cursor hooks template
         │   ├── copilot-hooks.example.json      # GitHub Copilot hooks template
         │   ├── claude-hooks.example.json       # Claude Code hooks template
+        │   ├── claude-managed-settings.example.json # Minimal Claude managed-settings snippet
         │   ├── opencode-plugin.example.ts      # OpenCode plugin template
         │   └── antigravity-workflow.example.md # Antigravity workflow template
         ├── .gitignore                          # Excludes secrets, venv, state
@@ -867,6 +886,14 @@ tail -f ./otel_hook.log
 ```bash
 echo '{"hook_event_name":"SessionStart","session_id":"test-123"}' | otel-hook
 ```
+
+For deterministic local export checks, disable the SDK batch processor for just the hook process:
+
+```bash
+printf '%s\n' '{"hook_event_name":"SessionStart","session_id":"test-123"}' | env IDE_OTEL_DISABLE_BATCH=1 otel-hook
+```
+
+This bypasses the SDK's background exporter only; `IDE_OTEL_BATCH_ON_STOP` still controls the hook's own session-level buffering.
 
 ### Common issues
 

--- a/enrichment_connectors.py
+++ b/enrichment_connectors.py
@@ -6,6 +6,7 @@ additional enrichers can be added without growing the main hook runtime.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 
 MemoryFacts = dict[str, list[str]]
@@ -15,6 +16,39 @@ MemorySummary = dict[str, object]
 
 def _empty_facts() -> MemoryFacts:
     return {"files": [], "tools": [], "entities": [], "commands": []}
+
+
+def normalize_memory_path(path: str, repo_root: str | None = None) -> str:
+    normalized = path.strip()
+    if not normalized:
+        return normalized
+    if repo_root and os.path.isabs(normalized):
+        repo_root_abs = os.path.abspath(repo_root)
+        candidate_abs = os.path.abspath(normalized)
+        try:
+            if os.path.commonpath([candidate_abs, repo_root_abs]) == repo_root_abs:
+                normalized = os.path.relpath(candidate_abs, repo_root_abs)
+        except ValueError:
+            pass
+    normalized = os.path.normpath(normalized)
+    return normalized.replace(os.sep, "/")
+
+
+def normalize_memory_summary(summary: dict, repo_root: str | None = None) -> dict:
+    files = summary.get("files")
+    if not isinstance(files, list):
+        return summary
+    normalized_files: list[str] = []
+    seen: set[str] = set()
+    for value in files:
+        if not isinstance(value, str):
+            continue
+        normalized = normalize_memory_path(value, repo_root=repo_root)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            normalized_files.append(normalized)
+    summary["files"] = normalized_files
+    return summary
 
 
 def file_connector(_event_name: str, data: dict) -> MemoryFacts:
@@ -86,6 +120,7 @@ def extract_event_memory_facts(
 def aggregate_generation_memory(
     batch: list,
     connectors: tuple[MemoryConnector, ...] = DEFAULT_MEMORY_CONNECTORS,
+    repo_root: str | None = None,
 ) -> MemorySummary:
     files: list[str] = []
     tools: list[str] = []
@@ -105,6 +140,7 @@ def aggregate_generation_memory(
         facts = extract_event_memory_facts(event_name, data, connectors=connectors)
 
         for value in facts["files"]:
+            value = normalize_memory_path(value, repo_root=repo_root)
             if value not in seen["files"]:
                 seen["files"].add(value)
                 files.append(value)
@@ -131,11 +167,14 @@ def aggregate_generation_memory(
     }
 
 
-def merge_memory_summaries(target: dict, source: MemorySummary) -> dict:
+def merge_memory_summaries(target: dict, source: MemorySummary, repo_root: str | None = None) -> dict:
+    normalize_memory_summary(target, repo_root=repo_root)
     for key in ("files", "tools", "entities", "commands"):
         existing = target.setdefault(key, [])
         seen = set(existing)
         for value in source.get(key, []):
+            if key == "files" and isinstance(value, str):
+                value = normalize_memory_path(value, repo_root=repo_root)
             if value not in seen:
                 seen.add(value)
                 existing.append(value)

--- a/enrichment_connectors.py
+++ b/enrichment_connectors.py
@@ -29,7 +29,8 @@ def normalize_memory_path(path: str, repo_root: str | None = None) -> str:
             if os.path.commonpath([candidate_abs, repo_root_abs]) == repo_root_abs:
                 normalized = os.path.relpath(candidate_abs, repo_root_abs)
         except ValueError:
-            pass
+            # Paths on different drives cannot be relativized; keep the absolute candidate.
+            normalized = candidate_abs
     normalized = os.path.normpath(normalized)
     return normalized.replace(os.sep, "/")
 

--- a/examples/claude-managed-settings.example.json
+++ b/examples/claude-managed-settings.example.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Minimal Claude Code managed-settings.json snippet for org-wide Claude telemetry.",
+  "_comment_2": "This configures Claude Code itself. otel-hook still reads its own otel_config.json because Claude strips OTEL_* from hook subprocesses.",
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.example.com:4317",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=******"
+  }
+}

--- a/examples/portable-dashboard.example.md
+++ b/examples/portable-dashboard.example.md
@@ -1,0 +1,33 @@
+---
+description: Portable, vendor-neutral dashboard blueprint for opentelemetry-hooks telemetry.
+---
+
+Use your backend's intrinsic span fields for **span name**, **span status**, **duration**, and **trace ID**. The attribute keys below are emitted by this repo as OpenTelemetry attributes, so you can translate the same view into Grafana, Jaeger, Honeycomb, Datadog, or any other OTLP-compatible backend without changing field names.
+
+## Suggested base filter
+
+- `service.name = <your OTEL_SERVICE_NAME>` (commonly `ide-agent`)
+
+## Lean dashboard panels
+
+| Panel | Filter | Group by | Measure |
+| --- | --- | --- | --- |
+| Sessions by agent | `span.name = gen_ai.client.session` | `gen_ai.client.name` | count |
+| Generations by model | `span.name = gen_ai.client.generation` | `gen_ai.request.model` | count |
+| Hook failures | `span.name starts with gen_ai.client.hook.` and (`status.code = ERROR` or `gen_ai.client.error` exists) | `gen_ai.client.name` | error count / total hook spans |
+| Tool activity | `span.name in {gen_ai.client.hook.PreToolUse, gen_ai.client.hook.PostToolUse, gen_ai.client.hook.PostToolUseFailure}` | `gen_ai.client.tool_name` | count or p95 duration |
+| Shell + MCP activity | `gen_ai.client.command` exists or `gen_ai.client.mcp_server` exists | `gen_ai.client.command`, `gen_ai.client.mcp_server`, `gen_ai.client.mcp_tool` | count |
+| Token usage | `gen_ai.usage.input_tokens` exists or `gen_ai.usage.output_tokens` exists | `gen_ai.client.name`, `gen_ai.request.model`, `gen_ai.provider.name` | sum input tokens, sum output tokens |
+
+## Useful drill-downs
+
+- **Single session trace**: filter `gen_ai.client.session.key = <session key>`
+- **Prompt lifecycle**: filter `span.name in {gen_ai.client.hook.UserPromptSubmit, gen_ai.client.generation, gen_ai.client.hook.Stop}`
+- **File edits**: filter `span.name = gen_ai.client.hook.AfterFileEdit`
+- **Wrapper vs inner engine**: compare `gen_ai.client.name`, `gen_ai.client.wrapper`, and `gen_ai.client.agent_engine`
+
+## Portability notes
+
+- Prefer `service.name`, `gen_ai.client.name`, `gen_ai.provider.name`, `gen_ai.request.model`, and `gen_ai.usage.*` as reusable dimensions.
+- Treat `gen_ai.client.session.key`, file paths, cwd, and tool input/output hashes as **trace drill-down fields**, not long-lived metric dimensions.
+- Translate `count`, `sum`, and `p95 duration` into your backend's native visualization or query language; the field names above stay the same.

--- a/otel_config.example.json
+++ b/otel_config.example.json
@@ -32,7 +32,7 @@
   "IDE_OTEL_LOG_EVENTS": "false",
   "IDE_OTEL_DEBUG_CONSOLE": "false",
 
-  "_comment_6": "=== Advanced ===",
+  "_comment_6": "=== Advanced (set IDE_OTEL_DISABLE_BATCH=true for deterministic tests) ===",
   "IDE_OTEL_DISABLE_BATCH": "false",
   "IDE_OTEL_STATE_TTL_SECONDS": "86400",
   "IDE_OTEL_STATE_CLEANUP_INTERVAL_SECONDS": "3600",

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -685,6 +685,8 @@ def _resolve_repository_context(data: Optional[dict] = None, session_ctx: Option
             value = session_ctx.get(key)
             if isinstance(value, str) and value.strip():
                 repo_ctx[key] = value.strip()
+    if repo_ctx.get("repo_root") and repo_ctx.get("vcs.repository.name"):
+        return repo_ctx
     if "repo_root" not in repo_ctx:
         for candidate in _candidate_repo_paths(data):
             search_root = _path_search_root(candidate)
@@ -696,6 +698,8 @@ def _resolve_repository_context(data: Optional[dict] = None, session_ctx: Option
                 break
     repo_root = repo_ctx.get("repo_root")
     if not repo_root:
+        return repo_ctx
+    if not os.path.exists(os.path.join(repo_root, ".git")):
         return repo_ctx
     git_root = _git_command_output(["git", "rev-parse", "--show-toplevel"], cwd=repo_root)
     if git_root:
@@ -1015,7 +1019,7 @@ def _resolved_agent_engine(
         return resolved
     if session_ctx:
         session_engine = _normalize_ide_name(session_ctx.get("agent_engine"))
-        if session_engine and session_ctx.get("agent_engine_confirmed"):
+        if session_engine and session_ctx.get("agent_engine_confirmed", True):
             return session_engine
     return None
 
@@ -2350,9 +2354,10 @@ def _maybe_enrich_session_context(session_key: Optional[str], session_ctx: Optio
             changed = True
     repo_root = session_ctx.get("repo_root")
     if repo_root and isinstance(session_ctx.get("memory"), dict):
-        before = json.dumps(session_ctx["memory"], sort_keys=True)
+        memory_files = session_ctx["memory"].get("files")
+        files_before = list(memory_files) if isinstance(memory_files, list) else memory_files
         normalize_memory_summary(session_ctx["memory"], repo_root=repo_root)
-        if json.dumps(session_ctx["memory"], sort_keys=True) != before:
+        if session_ctx["memory"].get("files") != files_before:
             changed = True
     if changed:
         _write_session_context(session_key, session_ctx)

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -42,6 +42,7 @@ from enrichment_connectors import (
     aggregate_generation_memory,
     extract_event_memory_facts,
     merge_memory_summaries,
+    normalize_memory_summary,
 )
 
 # Whether to attach OS/host attributes to every span in addition to resource attributes.
@@ -385,6 +386,20 @@ _INPUT_ALIASES = {
     "cacheReadInputTokens": "cache_read_input_tokens",
     "workspacePath": "workspace_path",
     "filePath": "file_path",
+    "userId": "user_id",
+    "userEmail": "user_email",
+    "userName": "user_name",
+    "permissionMode": "permission_mode",
+    "permissionDecision": "permission_decision",
+    "approvalPolicy": "approval_policy",
+    "approvalDecision": "approval_decision",
+    "approvalRequired": "approval_required",
+    "sandboxMode": "sandbox_mode",
+    "sandboxPolicy": "sandbox_policy",
+    "sandboxEnabled": "sandbox_enabled",
+    "isSandboxed": "is_sandboxed",
+    "toolChoice": "tool_choice",
+    "toolDecision": "tool_decision",
     "exitCode": "exit_code",
     "durationMs": "duration_ms",
     "loopCount": "loop_count",
@@ -559,6 +574,225 @@ def _lower_or_none(value: Optional[str]) -> Optional[str]:
         return None
     lowered = value.strip().lower()
     return lowered or None
+
+
+def _iter_enrichment_sources(data: Optional[dict], include_tool_payloads: bool = False):
+    if not isinstance(data, dict):
+        return
+    yield data
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        yield metadata
+    user = data.get("user")
+    if isinstance(user, dict):
+        yield user
+    if include_tool_payloads:
+        for key in ("tool_input", "tool_response"):
+            value = data.get(key)
+            if isinstance(value, dict):
+                yield value
+
+
+def _coerce_attribute_value(value):
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _path_search_root(path: str) -> Optional[str]:
+    if not isinstance(path, str) or not path.strip():
+        return None
+    expanded = os.path.abspath(path.strip())
+    if os.path.isdir(expanded):
+        return expanded
+    return os.path.dirname(expanded) or expanded
+
+
+def _candidate_repo_paths(data: Optional[dict]) -> list[str]:
+    if not isinstance(data, dict):
+        return []
+    candidates: list[str] = []
+    cwd = data.get("cwd") or data.get("workspace_path")
+    if isinstance(cwd, str) and cwd.strip():
+        candidates.append(cwd.strip())
+
+    def _append_path(value) -> None:
+        if not isinstance(value, str) or not value.strip():
+            return
+        raw = value.strip()
+        if os.path.isabs(raw):
+            candidates.append(raw)
+            return
+        if isinstance(cwd, str) and cwd.strip() and os.path.isabs(cwd.strip()):
+            candidates.append(os.path.join(cwd.strip(), raw))
+
+    _append_path(data.get("file_path"))
+    edits = data.get("edits")
+    if isinstance(edits, list):
+        for entry in edits:
+            if isinstance(entry, dict):
+                _append_path(entry.get("file_path") or entry.get("path"))
+    elif isinstance(edits, dict):
+        _append_path(edits.get("file_path") or edits.get("path"))
+    return candidates
+
+
+def _git_command_output(args: list[str], cwd: str) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            args,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _parse_repository_remote(remote_url: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+    if not isinstance(remote_url, str) or not remote_url.strip():
+        return None, None
+    normalized = remote_url.strip()
+    is_network_remote = False
+    if "://" in normalized:
+        is_network_remote = True
+        path = urllib.parse.urlparse(normalized).path or ""
+    elif "@" in normalized and ":" in normalized.split("@", 1)[1]:
+        is_network_remote = True
+        path = normalized.split(":", 1)[1]
+    else:
+        path = normalized
+    path = path.strip().strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    parts = [part for part in path.split("/") if part]
+    if not parts:
+        return None, None
+    owner = parts[-2] if is_network_remote and len(parts) >= 2 else None
+    return owner, parts[-1]
+
+
+def _resolve_repository_context(data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> dict:
+    repo_ctx: dict[str, str] = {}
+    if session_ctx:
+        for key in ("repo_root", "vcs.repository.owner", "vcs.repository.name"):
+            value = session_ctx.get(key)
+            if isinstance(value, str) and value.strip():
+                repo_ctx[key] = value.strip()
+    if "repo_root" not in repo_ctx:
+        for candidate in _candidate_repo_paths(data):
+            search_root = _path_search_root(candidate)
+            if not search_root:
+                continue
+            repo_root = _find_repo_root(search_root)
+            if repo_root and any(os.path.exists(os.path.join(repo_root, marker)) for marker in _REPO_MARKERS):
+                repo_ctx["repo_root"] = repo_root
+                break
+    repo_root = repo_ctx.get("repo_root")
+    if not repo_root:
+        return repo_ctx
+    git_root = _git_command_output(["git", "rev-parse", "--show-toplevel"], cwd=repo_root)
+    if git_root:
+        repo_ctx["repo_root"] = git_root
+        if "vcs.repository.name" not in repo_ctx or "vcs.repository.owner" not in repo_ctx:
+            remote_url = _git_command_output(["git", "config", "--get", "remote.origin.url"], cwd=git_root)
+            owner, name = _parse_repository_remote(remote_url)
+            if owner and "vcs.repository.owner" not in repo_ctx:
+                repo_ctx["vcs.repository.owner"] = owner
+            if name and "vcs.repository.name" not in repo_ctx:
+                repo_ctx["vcs.repository.name"] = name
+        if "vcs.repository.name" not in repo_ctx:
+            repo_name = os.path.basename(git_root.rstrip(os.sep))
+            if repo_name:
+                repo_ctx["vcs.repository.name"] = repo_name
+    return repo_ctx
+
+
+def _collect_repository_attributes(data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> dict:
+    attrs: dict[str, str] = {}
+    repo_ctx = _resolve_repository_context(data, session_ctx=session_ctx)
+    for key in ("vcs.repository.owner", "vcs.repository.name"):
+        value = repo_ctx.get(key)
+        if value:
+            attrs[key] = value
+    return attrs
+
+
+def _collect_user_identity_attributes(data: Optional[dict]) -> dict:
+    if not _safe_bool(os.getenv("IDE_OTEL_CAPTURE_USER_IDENTITY", "")):
+        return {}
+    attrs = {}
+    user_id = None
+    user_email = None
+    user = data.get("user") if isinstance(data, dict) else None
+    if isinstance(user, dict):
+        user_id = _first_present(user, ("user_id", "id", "login", "username", "user_name", "actor_id"))
+        user_email = _first_present(user, ("user_email", "email"))
+    sources = []
+    if isinstance(data, dict):
+        sources.append(data)
+        metadata = data.get("metadata")
+        if isinstance(metadata, dict):
+            sources.append(metadata)
+    for source in sources:
+        if user_id is None:
+            user_id = _first_present(source, ("user_id", "login", "username", "user_name", "actor_id"))
+        if user_email is None:
+            user_email = _first_present(source, ("user_email", "email"))
+        if user_id is not None and user_email is not None:
+            break
+    user_id = _coerce_attribute_value(user_id)
+    if user_id is not None:
+        attrs["user.id"] = str(user_id)
+    user_email = _coerce_attribute_value(user_email)
+    if isinstance(user_email, str):
+        if _safe_bool(os.getenv("IDE_OTEL_MASK_PROMPTS", "")):
+            user_email = _mask_text(user_email)
+        attrs["user.email"] = user_email
+    return attrs
+
+
+def _collect_governance_attributes(data: Optional[dict]) -> dict:
+    if not isinstance(data, dict):
+        return {}
+    attrs = {}
+    attr_map = (
+        (("permission_mode",), "gen_ai.client.permission_mode"),
+        (("permission_decision", "approval_decision"), "gen_ai.client.approval.decision"),
+        (("approval_policy",), "gen_ai.client.approval.policy"),
+        (("approval_required", "requires_approval"), "gen_ai.client.approval.required"),
+        (("sandbox_mode",), "gen_ai.client.sandbox.mode"),
+        (("sandbox_policy",), "gen_ai.client.sandbox.policy"),
+        (("sandbox_enabled", "is_sandboxed", "sandboxed"), "gen_ai.client.sandbox.enabled"),
+        (("tool_choice",), "gen_ai.client.tool_choice"),
+        (("tool_decision",), "gen_ai.client.tool_decision"),
+    )
+    for source in _iter_enrichment_sources(data, include_tool_payloads=True):
+        for keys, attr_name in attr_map:
+            if attr_name in attrs:
+                continue
+            value = _coerce_attribute_value(_first_present(source, keys))
+            if value is not None:
+                attrs[attr_name] = value
+    return attrs
+
+
+def _collect_event_enrichment_attributes(data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> dict:
+    attrs = _collect_repository_attributes(data, session_ctx=session_ctx)
+    attrs.update(_collect_user_identity_attributes(data))
+    attrs.update(_collect_governance_attributes(data))
+    return attrs
+
+
+def _apply_enrichment_attributes(span, data: Optional[dict] = None, session_ctx: Optional[dict] = None) -> None:
+    for key, value in _collect_event_enrichment_attributes(data, session_ctx=session_ctx).items():
+        _set_if_present(span, key, value)
 
 
 def _normalize_genai_output_type(value) -> Optional[str]:
@@ -781,9 +1015,8 @@ def _resolved_agent_engine(
         return resolved
     if session_ctx:
         session_engine = _normalize_ide_name(session_ctx.get("agent_engine"))
-        if session_engine and ide and session_engine != ide and not _has_strong_engine_signal(payload, session_engine):
-            return None
-        return session_engine
+        if session_engine and session_ctx.get("agent_engine_confirmed"):
+            return session_engine
     return None
 
 def _resolve_client_name(
@@ -1578,7 +1811,11 @@ def _force_flush_provider(timeout_millis: int = 500) -> None:
         _LOGGER.warning("log force_flush failed: %s", exc)
 
 
-def _init_tracing(ide: str = "cursor", client_name: Optional[str] = None) -> bool:
+def _init_tracing(
+    ide: str = "cursor",
+    client_name: Optional[str] = None,
+    resource_attributes: Optional[dict] = None,
+) -> bool:
     global _TRACING_INITIALIZED
     if _TRACING_INITIALIZED:
         return True
@@ -1593,6 +1830,10 @@ def _init_tracing(ide: str = "cursor", client_name: Optional[str] = None) -> boo
     app_name = os.getenv("IDE_OTEL_APP_NAME") or os.getenv("OTEL_SERVICE_NAME") or "ide-agent"
     resolved_client_name = client_name or ide
     resource_attrs = _parse_resource_attributes(os.getenv("OTEL_RESOURCE_ATTRIBUTES", ""))
+    if isinstance(resource_attributes, dict):
+        for key, value in resource_attributes.items():
+            if key and value is not None:
+                resource_attrs.setdefault(key, value)
     resource_attrs.setdefault("service.name", app_name)
     resource_attrs.setdefault("gen_ai.client.name", resolved_client_name)
     resource_attrs.setdefault("gen_ai.system", resolved_client_name)
@@ -1715,7 +1956,7 @@ def _fmt_duration(duration) -> str:
     return f"{duration}ms"
 
 
-def _emit_mcp_log(event_name: str, data: dict) -> None:
+def _emit_mcp_log(event_name: str, data: dict, session_ctx: Optional[dict] = None) -> None:
     """Emit a structured OTel log record for MCP events with full I/O payload.
 
     Cursor sends MCP events with these field names:
@@ -1738,6 +1979,7 @@ def _emit_mcp_log(event_name: str, data: dict) -> None:
         "gen_ai.client.mcp_tool": tool,
         "gen_ai.client.hook.event": event_name,
     }
+    attrs.update(_collect_event_enrichment_attributes(data, session_ctx=session_ctx))
     _tid, _sid = _inject_trace_context(attrs)
 
     # Capture input payload
@@ -1794,7 +2036,7 @@ def _emit_mcp_log(event_name: str, data: dict) -> None:
         logger.info("[%s] MCP result: %s/%s duration=%s", _sid, server, tool, _fmt_duration(duration), extra=attrs)
 
 
-def _emit_shell_log(event_name: str, data: dict) -> None:
+def _emit_shell_log(event_name: str, data: dict, session_ctx: Optional[dict] = None) -> None:
     """Emit a structured OTel log record for shell execution events."""
     if not _LOGS_INITIALIZED:
         return
@@ -1808,6 +2050,7 @@ def _emit_shell_log(event_name: str, data: dict) -> None:
         "gen_ai.client.command": command,
         "gen_ai.client.cwd": cwd,
     }
+    attrs.update(_collect_event_enrichment_attributes(data, session_ctx=session_ctx))
     _tid, _sid = _inject_trace_context(attrs)
 
     exit_code = data.get("exit_code")
@@ -1838,7 +2081,7 @@ def _emit_shell_log(event_name: str, data: dict) -> None:
         logger.info("[%s] Shell result: %s exit=%s duration=%s", _sid, command, exit_code, _fmt_duration(duration), extra=attrs)
 
 
-def _emit_tool_log(event_name: str, data: dict) -> None:
+def _emit_tool_log(event_name: str, data: dict, session_ctx: Optional[dict] = None) -> None:
     """Emit a structured OTel log record for tool use events."""
     if not _LOGS_INITIALIZED:
         return
@@ -1850,6 +2093,7 @@ def _emit_tool_log(event_name: str, data: dict) -> None:
         "gen_ai.client.hook.event": event_name,
         "gen_ai.client.tool_name": tool_name,
     }
+    attrs.update(_collect_event_enrichment_attributes(data, session_ctx=session_ctx))
     _tid, _sid = _inject_trace_context(attrs)
 
     for key in ("tool_id", "tool_use_id"):
@@ -1888,19 +2132,20 @@ def _emit_tool_log(event_name: str, data: dict) -> None:
         logger.info("[%s] Tool result: %s duration=%s", _sid, tool_name, _fmt_duration(duration), extra=attrs)
 
 
-def _emit_event_log(event_name: str, data: dict) -> None:
+def _emit_event_log(event_name: str, data: dict, session_ctx: Optional[dict] = None) -> None:
     """Emit OTel log records for hook events (dispatcher)."""
     if not _LOGS_INITIALIZED:
         return
     if event_name in _MCP_EVENTS:
-        _emit_mcp_log(event_name, data)
+        _emit_mcp_log(event_name, data, session_ctx=session_ctx)
     elif event_name in _SHELL_EVENTS:
-        _emit_shell_log(event_name, data)
+        _emit_shell_log(event_name, data, session_ctx=session_ctx)
     elif event_name in _TOOL_EVENTS:
-        _emit_tool_log(event_name, data)
+        _emit_tool_log(event_name, data, session_ctx=session_ctx)
     elif _safe_bool(os.getenv("IDE_OTEL_LOG_ALL_EVENTS", "")):
         logger = _get_otel_logger("events")
         all_attrs = {"gen_ai.client.hook.event": event_name}
+        all_attrs.update(_collect_event_enrichment_attributes(data, session_ctx=session_ctx))
         _tid, _sid = _inject_trace_context(all_attrs)
         logger.info("[%s] Hook event: %s", _sid, event_name, extra=all_attrs)
 
@@ -2061,9 +2306,12 @@ def _create_session_context(session_key: str, data: dict, ide: str) -> dict:
     if model := _first_present(data, ("request_model", "model", "model_name")):
         ctx["last_known_model"] = model
 
-    agent_engine = _detect_agent_engine(data)
+    ctx.update(_resolve_repository_context(data))
+
+    agent_engine = _resolved_agent_engine(data, ide=ide)
     if agent_engine and agent_engine != ide:
         ctx["agent_engine"] = agent_engine
+        ctx["agent_engine_confirmed"] = True
     lock_path = os.path.join(_LOCK_DIR, f"{re.sub(r'[^A-Za-z0-9_.-]+', '_', session_key)}.lock")
     with _acquire_lock(lock_path):
         _atomic_write_json(_session_path(session_key), ctx)
@@ -2088,6 +2336,27 @@ def _write_session_context(session_key: str, ctx: dict) -> None:
     lock_path = os.path.join(_LOCK_DIR, f"{re.sub(r'[^A-Za-z0-9_.-]+', '_', session_key)}.lock")
     with _acquire_lock(lock_path):
         _atomic_write_json(_session_path(session_key), ctx)
+
+
+def _maybe_enrich_session_context(session_key: Optional[str], session_ctx: Optional[dict], data: dict) -> Optional[dict]:
+    if not session_key or not session_ctx:
+        return session_ctx
+    repo_ctx = _resolve_repository_context(data, session_ctx=session_ctx)
+    changed = False
+    for key in ("repo_root", "vcs.repository.owner", "vcs.repository.name"):
+        value = repo_ctx.get(key)
+        if value and session_ctx.get(key) != value:
+            session_ctx[key] = value
+            changed = True
+    repo_root = session_ctx.get("repo_root")
+    if repo_root and isinstance(session_ctx.get("memory"), dict):
+        before = json.dumps(session_ctx["memory"], sort_keys=True)
+        normalize_memory_summary(session_ctx["memory"], repo_root=repo_root)
+        if json.dumps(session_ctx["memory"], sort_keys=True) != before:
+            changed = True
+    if changed:
+        _write_session_context(session_key, session_ctx)
+    return session_ctx
 
 
 def _maybe_bind_session_to_upstream_context(session_key: Optional[str], session_ctx: Optional[dict], data: dict) -> Optional[dict]:
@@ -2617,6 +2886,7 @@ def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Opt
     """Attach all attributes to a span and emit OTel log records."""
     span.set_attribute("gen_ai.client.hook.event", event_name)
     _set_client_identity_attributes(span, ide, data=data, session_ctx=session_ctx)
+    _apply_enrichment_attributes(span, data, session_ctx=session_ctx)
 
     # Optionally attach OS / host attributes on every span.
     # These are already present as resource attributes via OTEL_RESOURCE_ATTRIBUTES,
@@ -2631,7 +2901,7 @@ def _populate_span(span, event_name: str, data: dict, ide: str, session_ctx: Opt
     _set_if_present(span, "gen_ai.client.version", client_version)
 
     # Emit structured OTel log record (MCP, shell, tool — correlated with this span)
-    _emit_event_log(event_name, data)
+    _emit_event_log(event_name, data, session_ctx=session_ctx)
     _set_if_present(span, "gen_ai.client.session_id", data.get("session_id") or data.get("conversation_id"))
     _set_if_present(span, "gen_ai.client.generation_id", data.get("generation_id"))
     _set_if_present(span, "gen_ai.client.turn_id", data.get("turn_id"))
@@ -2745,9 +3015,9 @@ def _extract_event_memory_facts(event_name: str, data: dict) -> dict:
     return extract_event_memory_facts(event_name, data)
 
 
-def _aggregate_generation_memory(batch: list) -> dict:
+def _aggregate_generation_memory(batch: list, repo_root: Optional[str] = None) -> dict:
     """Backward-compatible wrapper for connector-based enrichment."""
-    return aggregate_generation_memory(batch)
+    return aggregate_generation_memory(batch, repo_root=repo_root)
 
 
 def _apply_memory_summary_attrs(span, prefix: str, summary: dict) -> None:
@@ -2801,7 +3071,8 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
          if _first_present(e["data"], ("request_model", "model", "model_name"))),
         None
     )
-    memory_summary = _aggregate_generation_memory(batch)
+    repo_root = (session_ctx or {}).get("repo_root")
+    memory_summary = _aggregate_generation_memory(batch, repo_root=repo_root)
 
     span_kind = SpanKind.INTERNAL if SpanKind is not None else None
     gen_span = tracer.start_span(
@@ -2814,7 +3085,8 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
         gen_span.set_attribute("gen_ai.client.event.count", len(batch))
         _set_if_present(gen_span, "gen_ai.request.model", batch_model)
         _apply_memory_summary_attrs(gen_span, "gen_ai.client.memory", memory_summary)
-        _set_client_identity_attributes(gen_span, ide, agent_engine=(session_ctx or {}).get("agent_engine"))
+        _set_client_identity_attributes(gen_span, ide, session_ctx=session_ctx)
+        _apply_enrichment_attributes(gen_span, batch[0].get("data") if batch else {}, session_ctx=session_ctx)
         _log_with_span(_LOGGER, logging.INFO, gen_span, "Generation span: gen_key=%s events=%d", gen_key, len(batch))
 
         for idx, entry in enumerate(batch):
@@ -2836,7 +3108,7 @@ def _flush_generation(tracer, gen_key: str, session_ctx: Optional[dict], ide: st
 
     if session_ctx is not None:
         session_memory = session_ctx.setdefault("memory", {})
-        merge_memory_summaries(session_memory, memory_summary)
+        merge_memory_summaries(session_memory, memory_summary, repo_root=repo_root)
 
     if flush:
         _force_flush_provider()
@@ -2857,9 +3129,10 @@ def _flush_session(tracer, session_key: str, session_ctx: dict, ide: str, flush:
     )
     with _span_context(session_span):
         session_span.set_attribute("gen_ai.client.session_id", session_key)
-        _set_client_identity_attributes(session_span, ide, agent_engine=session_ctx.get("agent_engine"))
+        _set_client_identity_attributes(session_span, ide, session_ctx=session_ctx)
         session_span.set_attribute("gen_ai.client.generation_count", session_ctx.get("generation_count", 0))
         session_span.set_attribute("gen_ai.client.session.duration_ms", (end_ns - start_ns) // 1_000_000)
+        _apply_enrichment_attributes(session_span, {}, session_ctx=session_ctx)
         _apply_memory_summary_attrs(session_span, "gen_ai.client.memory", session_ctx.get("memory", {}))
         _log_with_span(_LOGGER, logging.INFO, session_span, "Session span: session=%s", session_key)
         session_span.end(end_time=end_ns)
@@ -2891,6 +3164,7 @@ def main() -> int:
     sk = _session_key(data)
     session_ctx = _load_session_context(sk)
     session_ctx = _maybe_bind_session_to_upstream_context(sk, session_ctx, data)
+    session_ctx = _maybe_enrich_session_context(sk, session_ctx, data)
     agent_engine = _resolved_agent_engine(data, session_ctx, ide=ide)
 
     if _safe_bool(os.getenv("IDE_OTEL_LOG_EVENTS", "")):
@@ -2925,7 +3199,11 @@ def main() -> int:
                 _emit_stdout_response(event_name, ide, data)
                 return 0
 
-    if not _init_tracing(ide, client_name=_resolve_client_name(ide, data=data, agent_engine=agent_engine, session_ctx=session_ctx)):
+    if not _init_tracing(
+        ide,
+        client_name=_resolve_client_name(ide, data=data, agent_engine=agent_engine, session_ctx=session_ctx),
+        resource_attributes=_collect_repository_attributes(data, session_ctx=session_ctx),
+    ):
         _emit_stdout_response(event_name, ide, data)
         return 0
 
@@ -2936,9 +3214,11 @@ def main() -> int:
     _flush_stale_sessions(tracer)
 
     try:
-        if sk and session_ctx and agent_engine and agent_engine != ide and session_ctx.get("agent_engine") != agent_engine:
-            session_ctx["agent_engine"] = agent_engine
-            _write_session_context(sk, session_ctx)
+        if sk and session_ctx and agent_engine and agent_engine != ide:
+            if session_ctx.get("agent_engine") != agent_engine or not session_ctx.get("agent_engine_confirmed"):
+                session_ctx["agent_engine"] = agent_engine
+                session_ctx["agent_engine_confirmed"] = True
+                _write_session_context(sk, session_ctx)
 
         # Update last_known_model if present in current event (Fix A)
         if sk and session_ctx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ py-modules = ["otel_hook", "enrichment_connectors"]
 "share/opentelemetry-hooks/plugin" = ["plugin/opencode.ts"]
 "share/opentelemetry-hooks/examples" = [
     "examples/antigravity-workflow.example.md",
+    "examples/claude-managed-settings.example.json",
     "examples/claude-hooks.example.json",
     "examples/codex-hooks.example.json",
     "examples/copilot-hooks.example.json",

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -117,6 +117,21 @@ class TestMemoryAggregation:
         assert session["commands"] == ["pytest -q"]
         assert session["tool_counts"]["read"] == 2
 
+    def test_connector_normalizes_repo_relative_paths(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        file_path = repo_root / "src" / "main.py"
+        summary = enrichment_connectors.aggregate_generation_memory(
+            [{"event": "AfterFileEdit", "data": {"file_path": str(file_path)}}],
+            repo_root=str(repo_root),
+        )
+        assert summary["files"] == ["src/main.py"]
+
+    def test_merge_normalizes_existing_files_once_repo_root_known(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        target = {"files": [str(repo_root / "README.md")], "tool_counts": {}}
+        enrichment_connectors.merge_memory_summaries(target, {"files": [], "tool_counts": {}}, repo_root=str(repo_root))
+        assert target["files"] == ["README.md"]
+
 # ── Event normalization ───────────────────────────────────────────────────
 
 
@@ -155,6 +170,12 @@ class TestNormalizeInputData:
             "cacheCreationInputTokens": 3,
             "cacheReadInputTokens": 2,
             "agentName": "planner",
+            "userId": "user-1",
+            "userEmail": "user@example.com",
+            "permissionMode": "acceptEdits",
+            "approvalDecision": "approved",
+            "sandboxMode": "workspace-write",
+            "toolChoice": "required",
             "hookEventType": "PreToolUse",
             "traceId": "a" * 32,
             "spanId": "b" * 16,
@@ -174,6 +195,12 @@ class TestNormalizeInputData:
         assert data["cache_creation_input_tokens"] == 3
         assert data["cache_read_input_tokens"] == 2
         assert data["agent_name"] == "planner"
+        assert data["user_id"] == "user-1"
+        assert data["user_email"] == "user@example.com"
+        assert data["permission_mode"] == "acceptEdits"
+        assert data["approval_decision"] == "approved"
+        assert data["sandbox_mode"] == "workspace-write"
+        assert data["tool_choice"] == "required"
         assert data["hook_event_type"] == "PreToolUse"
         assert data["trace_id"] == "a" * 32
         assert data["span_id"] == "b" * 16
@@ -905,6 +932,62 @@ class TestClientIdentityAttributes:
         assert "gen_ai.client.wrapper" not in attrs
         assert "gen_ai.client.agent_engine" not in attrs
 
+    def test_session_context_engine_promotes_nested_client_identity(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"session_id": "sess-1"},
+            session_ctx={"agent_engine": "gemini", "agent_engine_confirmed": True},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "gemini"
+        assert attrs["gen_ai.client.wrapper"] == "claude"
+        assert attrs["gen_ai.client.agent_engine"] == "gemini"
+
+
+class TestRepositoryEnrichment:
+    def test_resolve_repository_context_uses_git_remote(self, monkeypatch, tmp_path):
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / ".git").mkdir()
+
+        def fake_run(args, **kwargs):
+            if args == ["git", "rev-parse", "--show-toplevel"]:
+                return mock.Mock(returncode=0, stdout=f"{repo_root}\n")
+            if args == ["git", "config", "--get", "remote.origin.url"]:
+                return mock.Mock(returncode=0, stdout="git@github.com:o11y-dev/opentelemetry-hooks.git\n")
+            raise AssertionError(f"unexpected git command: {args}")
+
+        monkeypatch.setattr(otel_hook, "_find_repo_root", lambda _cwd: str(repo_root))
+        monkeypatch.setattr(otel_hook.subprocess, "run", fake_run)
+
+        ctx = otel_hook._resolve_repository_context({"cwd": str(repo_root)})
+
+        assert ctx["repo_root"] == str(repo_root)
+        assert ctx["vcs.repository.owner"] == "o11y-dev"
+        assert ctx["vcs.repository.name"] == "opentelemetry-hooks"
+
+    def test_resolve_repository_context_skips_vcs_attrs_for_marker_only_project(self, monkeypatch, tmp_path):
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        (project_root / ".claude").mkdir()
+
+        monkeypatch.setattr(otel_hook, "_find_repo_root", lambda _cwd: str(project_root))
+        monkeypatch.setattr(
+            otel_hook,
+            "_git_command_output",
+            lambda args, cwd: None if args[:3] == ["git", "rev-parse", "--show-toplevel"] else None,
+        )
+
+        ctx = otel_hook._resolve_repository_context({"cwd": str(project_root)})
+
+        assert ctx["repo_root"] == str(project_root)
+        assert "vcs.repository.owner" not in ctx
+        assert "vcs.repository.name" not in ctx
+
 
 # ── Log endpoint derivation ───────────────────────────────────────────────
 
@@ -1070,6 +1153,16 @@ class TestSessionContext:
                 loaded = otel_hook._load_session_context("sess-bind")
                 assert loaded["trace_id"] == "d" * 32
                 assert loaded["upstream_parent_span_id"] == "e" * 16
+
+    def test_create_session_context_requires_confirmed_nested_engine(self, tmp_path):
+        with mock.patch.object(otel_hook, "_SESSION_DIR", str(tmp_path)):
+            with mock.patch.object(otel_hook, "_LOCK_DIR", str(tmp_path / "locks")):
+                ctx = otel_hook._create_session_context(
+                    "sess-engine",
+                    {"transcript_path": "/tmp/transcript.jsonl"},
+                    "cursor",
+                )
+                assert "agent_engine" not in ctx
 
 
 class TestUpstreamTraceContext:
@@ -1808,6 +1901,74 @@ class TestSetCodexToolAttrs:
 
     def test_permission_request_in_tool_events(self):
         assert "PermissionRequest" in otel_hook._TOOL_EVENTS
+
+
+class TestEventEnrichmentAttributes:
+    def test_user_identity_capture_is_opt_in(self, monkeypatch):
+        monkeypatch.delenv("IDE_OTEL_CAPTURE_USER_IDENTITY", raising=False)
+        attrs = otel_hook._collect_event_enrichment_attributes({
+            "user_id": "user-1",
+            "user_email": "user@example.com",
+        })
+        assert "user.id" not in attrs
+        assert "user.email" not in attrs
+
+    def test_collects_user_and_governance_attributes(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_CAPTURE_USER_IDENTITY", "1")
+        attrs = otel_hook._collect_event_enrichment_attributes({
+            "user": {"id": "user-1", "email": "user@example.com"},
+            "permission_mode": "acceptEdits",
+            "permission_decision": "approved",
+            "approval_policy": "manual",
+            "approval_required": True,
+            "sandbox_mode": "workspace-write",
+            "sandbox_policy": "strict",
+            "tool_choice": "required",
+            "tool_decision": "auto",
+        })
+        assert attrs["user.id"] == "user-1"
+        assert attrs["user.email"] == "user@example.com"
+        assert attrs["gen_ai.client.permission_mode"] == "acceptEdits"
+        assert attrs["gen_ai.client.approval.decision"] == "approved"
+        assert attrs["gen_ai.client.approval.policy"] == "manual"
+        assert attrs["gen_ai.client.approval.required"] is True
+        assert attrs["gen_ai.client.sandbox.mode"] == "workspace-write"
+        assert attrs["gen_ai.client.sandbox.policy"] == "strict"
+        assert attrs["gen_ai.client.tool_choice"] == "required"
+        assert attrs["gen_ai.client.tool_decision"] == "auto"
+
+    def test_nested_user_id_wins_over_top_level_object_id(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_CAPTURE_USER_IDENTITY", "1")
+        attrs = otel_hook._collect_event_enrichment_attributes({
+            "id": "response-123",
+            "user": {"id": "user-1", "email": "user@example.com"},
+        })
+        assert attrs["user.id"] == "user-1"
+        assert attrs["user.email"] == "user@example.com"
+
+    def test_tool_logs_include_enrichment_attributes(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_CAPTURE_USER_IDENTITY", "1")
+        monkeypatch.setattr(otel_hook, "_LOGS_INITIALIZED", True)
+        monkeypatch.setattr(otel_hook, "_inject_trace_context", lambda attrs: ("trace", "span"))
+        logger = mock.MagicMock()
+        monkeypatch.setattr(otel_hook, "_get_otel_logger", lambda _name: logger)
+
+        otel_hook._emit_tool_log(
+            "PermissionRequest",
+            {
+                "tool_name": "bash",
+                "user_id": "user-1",
+                "permission_mode": "acceptEdits",
+                "sandbox_mode": "workspace-write",
+            },
+            session_ctx={"vcs.repository.name": "opentelemetry-hooks"},
+        )
+
+        extra = logger.info.call_args.kwargs["extra"]
+        assert extra["user.id"] == "user-1"
+        assert extra["gen_ai.client.permission_mode"] == "acceptEdits"
+        assert extra["gen_ai.client.sandbox.mode"] == "workspace-write"
+        assert extra["vcs.repository.name"] == "opentelemetry-hooks"
 
 
 # ── New IDE name aliases ─────────────────────────────────────────────────

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -18,6 +18,11 @@ import enrichment_connectors
 import otel_hook
 
 
+@pytest.fixture(autouse=True)
+def _disable_process_tree_detection(monkeypatch):
+    monkeypatch.setattr(otel_hook, "_detect_ide_from_process_tree", lambda: None)
+
+
 # ── Helper functions ──────────────────────────────────────────────────────
 
 
@@ -833,7 +838,7 @@ class TestGenAISemconv:
         attrs = self._attrs(span)
         assert attrs["gen_ai.system"] == "gemini"
 
-    def test_cursor_with_claude_engine_keeps_cursor_as_genai_system(self):
+    def test_cursor_with_unconfirmed_claude_engine_keeps_cursor_as_genai_system(self):
         span = mock.MagicMock()
 
         otel_hook._apply_genai_semconv(
@@ -841,7 +846,7 @@ class TestGenAISemconv:
             "PreToolUse",
             {"transcript_path": "/tmp/transcript.jsonl"},
             "cursor",
-            session_ctx={"agent_engine": "claude"},
+            session_ctx={"agent_engine": "claude", "agent_engine_confirmed": False},
         )
 
         attrs = self._attrs(span)
@@ -947,6 +952,36 @@ class TestClientIdentityAttributes:
         assert attrs["gen_ai.client.wrapper"] == "claude"
         assert attrs["gen_ai.client.agent_engine"] == "gemini"
 
+    def test_legacy_session_context_engine_promotes_nested_client_identity(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"session_id": "sess-1"},
+            session_ctx={"agent_engine": "gemini"},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "gemini"
+        assert attrs["gen_ai.client.wrapper"] == "claude"
+        assert attrs["gen_ai.client.agent_engine"] == "gemini"
+
+    def test_unconfirmed_session_context_engine_keeps_outer_client_identity(self):
+        span = mock.MagicMock()
+
+        otel_hook._set_client_identity_attributes(
+            span,
+            "claude",
+            data={"session_id": "sess-1"},
+            session_ctx={"agent_engine": "gemini", "agent_engine_confirmed": False},
+        )
+
+        attrs = self._attrs(span)
+        assert attrs["gen_ai.client.name"] == "claude"
+        assert "gen_ai.client.wrapper" not in attrs
+        assert "gen_ai.client.agent_engine" not in attrs
+
 
 class TestRepositoryEnrichment:
     def test_resolve_repository_context_uses_git_remote(self, monkeypatch, tmp_path):
@@ -970,6 +1005,28 @@ class TestRepositoryEnrichment:
         assert ctx["vcs.repository.owner"] == "o11y-dev"
         assert ctx["vcs.repository.name"] == "opentelemetry-hooks"
 
+    def test_resolve_repository_context_reuses_complete_session_context(self, monkeypatch, tmp_path):
+        repo_root = tmp_path / "repo"
+        session_ctx = {
+            "repo_root": str(repo_root),
+            "vcs.repository.owner": "o11y-dev",
+            "vcs.repository.name": "opentelemetry-hooks",
+        }
+        monkeypatch.setattr(
+            otel_hook,
+            "_find_repo_root",
+            mock.Mock(side_effect=AssertionError("unexpected root lookup")),
+        )
+        monkeypatch.setattr(
+            otel_hook,
+            "_git_command_output",
+            mock.Mock(side_effect=AssertionError("unexpected git lookup")),
+        )
+
+        ctx = otel_hook._resolve_repository_context({"cwd": str(repo_root)}, session_ctx=session_ctx)
+
+        assert ctx == session_ctx
+
     def test_resolve_repository_context_skips_vcs_attrs_for_marker_only_project(self, monkeypatch, tmp_path):
         project_root = tmp_path / "project"
         project_root.mkdir()
@@ -979,7 +1036,7 @@ class TestRepositoryEnrichment:
         monkeypatch.setattr(
             otel_hook,
             "_git_command_output",
-            lambda args, cwd: None if args[:3] == ["git", "rev-parse", "--show-toplevel"] else None,
+            mock.Mock(side_effect=AssertionError("unexpected git lookup")),
         )
 
         ctx = otel_hook._resolve_repository_context({"cwd": str(project_root)})


### PR DESCRIPTION
## Summary
- add repository enrichment, repo-relative memory normalization, and improved nested-agent identity attribution
- add opt-in user identity plus permission/sandbox/tool-decision telemetry
- document enterprise rollout, privacy caveats, and portable observability examples

## Testing
- uv run --python 3.12 --with pytest pytest tests/test_otel_hook.py -q
- uv run --python 3.12 --with ruff ruff check otel_hook.py tests/test_otel_hook.py
- git diff --check HEAD
