### PR TITLE
Prevent Stop hook export timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.14.1 (unreleased)
+
+### Fixed
+- Prevented a hook running under one Python ABI from importing compiled OpenTelemetry dependencies from a stale bootstrap venv created by another Python version.
+- Bounded stale-session finalization per interactive hook invocation so an accumulated backlog cannot exhaust the agent's Stop-hook timeout.
+- Compacted oversized buffered tool responses while preserving exact length and digest evidence, preventing large tool results from inflating pending hook state.
+
 ## 0.14.0 (2026-07-22)
 
 ### Added

--- a/otel_hook.py
+++ b/otel_hook.py
@@ -111,8 +111,42 @@ def _resolve_hook_home() -> str:
 
 
 _HOOK_DIR = _resolve_hook_home()
-_VENV_DIR = os.path.join(_HOOK_DIR, ".venv")
-_SETUP_LOCK = os.path.join(_HOOK_DIR, ".state", "setup.lock")
+
+
+def _venv_site_packages_path(venv_dir: str) -> str:
+    """Return the site-packages path compatible with this Python runtime."""
+    version = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    return os.path.join(venv_dir, "lib", version, "site-packages")
+
+
+def _select_bootstrap_venv_dir(hook_dir: str) -> str:
+    """Reuse a compatible legacy venv or isolate bootstrap deps by Python ABI."""
+    legacy = os.path.join(hook_dir, ".venv")
+    if os.path.isdir(_venv_site_packages_path(legacy)):
+        return legacy
+    suffix = f".venv-py{sys.version_info.major}.{sys.version_info.minor}"
+    return os.path.join(hook_dir, suffix)
+
+
+def _runtime_has_otel_dependencies() -> bool:
+    """Return whether the invoking environment already owns the hook SDK deps."""
+    required = (
+        "opentelemetry.sdk.trace.export",
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+    )
+    try:
+        return all(importlib.util.find_spec(module) is not None for module in required)
+    except (ImportError, AttributeError, ValueError):
+        return False
+
+
+_VENV_DIR = _select_bootstrap_venv_dir(_HOOK_DIR)
+_SETUP_LOCK = os.path.join(
+    _HOOK_DIR,
+    ".state",
+    f"setup-py{sys.version_info.major}.{sys.version_info.minor}.lock",
+)
 
 
 def _auto_provision_venv() -> None:
@@ -148,12 +182,12 @@ def _auto_provision_venv() -> None:
             pass
 
 
-_auto_provision_venv()
-
-_VENV_SP = glob.glob(os.path.join(_VENV_DIR, "lib", "python*", "site-packages"))
-for _sp in _VENV_SP:
-    if _sp not in sys.path:
-        sys.path.insert(0, _sp)
+_RUNTIME_HAS_OTEL_DEPENDENCIES = _runtime_has_otel_dependencies()
+if not _RUNTIME_HAS_OTEL_DEPENDENCIES:
+    _auto_provision_venv()
+    _venv_site_packages = _venv_site_packages_path(_VENV_DIR)
+    if os.path.isdir(_venv_site_packages) and _venv_site_packages not in sys.path:
+        sys.path.insert(0, _venv_site_packages)
 
 class _TraceShim:
     """Small shim so tests can monkeypatch trace methods before lazy load."""
@@ -1207,6 +1241,34 @@ def _normalize_input_data(data: dict) -> dict:
     return normalized or data
 
 
+def _bound_tool_response_payload(data: dict) -> None:
+    """Keep buffered tool responses small while preserving exact size evidence."""
+    value = data.get("tool_response")
+    if value is None:
+        return
+
+    text = _stringify(value)
+    data["tool_response_length"] = len(text)
+    data["tool_response_sha256"] = _hash_text(text)
+
+    # Provider aliases are normalized before this boundary. Keeping both copies
+    # defeats the payload bound for camelCase callbacks.
+    data.pop("toolResponse", None)
+
+    max_chars = _text_max_chars()
+    if len(text) <= max_chars:
+        return
+
+    data["tool_response_truncated"] = True
+    retain_preview = _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")) or _safe_bool(
+        os.getenv("IDE_OTEL_MCP_LOG_PAYLOAD", "true")
+    )
+    if retain_preview and max_chars > 0:
+        data["tool_response"] = text[:max_chars]
+    else:
+        data.pop("tool_response", None)
+
+
 @dataclass(frozen=True, slots=True)
 class ConversationRecord:
     """One privacy-controlled conversation fact extracted from a hook callback."""
@@ -1338,6 +1400,7 @@ class ProviderEventAdapter:
             parent_span_id=self._native_span_id(normalized.get("native_parent_span_id")),
         )
         self._store_privacy_safe_conversation(event_name, normalized, conversation)
+        _bound_tool_response_payload(normalized)
         return CanonicalHookEvent(
             provider=self.provider,
             original_event_name=original_event_name,
@@ -1708,6 +1771,14 @@ def _state_cleanup_interval_seconds() -> int:
         return 3600
 
 
+def _stale_flush_session_limit() -> int:
+    """Bound best-effort stale maintenance performed by an interactive hook."""
+    try:
+        return max(0, int(os.getenv("IDE_OTEL_STALE_FLUSH_MAX_SESSIONS", "1")))
+    except (TypeError, ValueError):
+        return 1
+
+
 def _state_lock_timeout_seconds() -> float:
     try:
         return float(os.getenv("IDE_OTEL_STATE_LOCK_TIMEOUT_SECONDS", "2"))
@@ -1810,19 +1881,34 @@ def _flush_stale_sessions(tracer) -> None:
     if not os.path.isdir(_SESSION_DIR):
         return
 
+    session_limit = _stale_flush_session_limit()
+    if session_limit <= 0:
+        return
+
     cutoff = time.time() - ttl
     flushed_any = False
+    attempted = 0
+    paths = []
     for name in os.listdir(_SESSION_DIR):
         path = os.path.join(_SESSION_DIR, name)
         try:
-            if not os.path.isfile(path) or os.path.getmtime(path) >= cutoff:
-                continue
+            mtime = os.path.getmtime(path)
+            if os.path.isfile(path) and mtime < cutoff:
+                paths.append((mtime, path))
+        except OSError:
+            continue
+
+    for _mtime, path in sorted(paths):
+        try:
             with open(path, "r", encoding="utf-8") as fh:
                 ctx = json.load(fh)
             if not ctx:
                 os.remove(path)
                 continue
-            session_key = name.removesuffix(".json")
+            if attempted >= session_limit:
+                break
+            attempted += 1
+            session_key = os.path.basename(path).removesuffix(".json")
             ide = ctx.get("ide", "unknown")
             if _local_spans_enabled():
                 _enable_file_exporter(
@@ -4764,6 +4850,8 @@ def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
             span.set_attribute("gen_ai.client.tool.input.sha256", _hash_text(text))
 
     tool_response = data.get("tool_response")
+    response_length = _int_or_none(data.get("tool_response_length"))
+    response_sha256 = data.get("tool_response_sha256")
     if isinstance(tool_response, dict):
         # Flatten full response only when explicitly opted in (same gate as tool input above)
         if _safe_bool(os.getenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", "")):
@@ -4780,11 +4868,23 @@ def _set_codex_tool_attrs(span, event_name: str, data: dict) -> None:
                     _set_if_present(span, key, value)
         else:
             # Always emit length+digest for cardinality-safe observability
-            text = _stringify(tool_response)
-            span.set_attribute("gen_ai.client.tool.response.length", len(text))
-            span.set_attribute("gen_ai.client.tool.response.sha256", _hash_text(text))
+            if response_length is None or not response_sha256:
+                text = _stringify(tool_response)
+                response_length = len(text)
+                response_sha256 = _hash_text(text)
+            span.set_attribute("gen_ai.client.tool.response.length", response_length)
+            span.set_attribute("gen_ai.client.tool.response.sha256", response_sha256)
     elif tool_response is not None:
         _maybe_attach_text(span, "tool_response", _stringify(tool_response))
+        if response_length is not None:
+            span.set_attribute("gen_ai.client.tool.response.length", response_length)
+        if response_sha256:
+            span.set_attribute("gen_ai.client.tool.response.sha256", response_sha256)
+    else:
+        if response_length is not None:
+            span.set_attribute("gen_ai.client.tool.response.length", response_length)
+        if response_sha256:
+            span.set_attribute("gen_ai.client.tool.response.sha256", response_sha256)
 
 
 def _flatten(out: dict, prefix: str, data: dict) -> None:

--- a/tests/test_otel_hook.py
+++ b/tests/test_otel_hook.py
@@ -2213,6 +2213,35 @@ class TestFlushStaleSessions:
         tracer.start_span.assert_not_called()
         assert sess_file.exists()
 
+    def test_bounds_stale_finalization_to_oldest_session(self, monkeypatch, tmp_path):
+        session_dir = tmp_path / "sessions"
+        session_dir.mkdir()
+        now = time.time()
+        for index in range(3):
+            path = session_dir / f"stale-{index}.json"
+            path.write_text(json.dumps({"trace_id": str(index), "ide": "codex"}))
+            mtime = now - 100_000 + index
+            os.utime(path, (mtime, mtime))
+
+        finalized = []
+
+        def finalize(_tracer, session_key, _ctx, _ide):
+            finalized.append(session_key)
+            os.remove(session_dir / f"{session_key}.json")
+            return True
+
+        monkeypatch.setenv("IDE_OTEL_STALE_FLUSH_MAX_SESSIONS", "1")
+        monkeypatch.setattr(otel_hook, "_finalize_session", finalize)
+        monkeypatch.setattr(otel_hook, "_SESSION_DIR", str(session_dir))
+
+        otel_hook._flush_stale_sessions(mock.MagicMock())
+
+        assert finalized == ["stale-0"]
+        assert sorted(path.name for path in session_dir.iterdir()) == [
+            "stale-1.json",
+            "stale-2.json",
+        ]
+
 
 # ── Flatten helper ────────────────────────────────────────────────────────
 
@@ -2544,6 +2573,24 @@ class TestResolveHookHome:
         assert result == str(script_dir)
 
 
+class TestBootstrapVenvSelection:
+    def test_reuses_legacy_venv_only_when_python_abi_matches(self, tmp_path):
+        legacy = tmp_path / ".venv"
+        expected = Path(otel_hook._venv_site_packages_path(str(legacy)))
+        expected.mkdir(parents=True)
+
+        assert otel_hook._select_bootstrap_venv_dir(str(tmp_path)) == str(legacy)
+
+    def test_uses_versioned_venv_when_legacy_python_abi_differs(self, tmp_path):
+        incompatible = tmp_path / ".venv" / "lib" / "python9.9" / "site-packages"
+        incompatible.mkdir(parents=True)
+
+        selected = otel_hook._select_bootstrap_venv_dir(str(tmp_path))
+
+        expected_suffix = f".venv-py{sys.version_info.major}.{sys.version_info.minor}"
+        assert selected == str(tmp_path / expected_suffix)
+
+
 class TestFindExampleConfig:
     def test_finds_file_next_to_module(self, monkeypatch, tmp_path):
         """When otel_config.example.json is next to __file__, it is returned."""
@@ -2712,6 +2759,35 @@ class _FakeSpan:
 
 
 class TestSetCodexToolAttrs:
+    def test_large_response_is_bounded_before_buffering(self, monkeypatch):
+        monkeypatch.setenv("IDE_OTEL_TEXT_MAX_CHARS", "64")
+        original = {"output": "x" * 10_000}
+        event = otel_hook._event_adapter_for("codex").normalize(
+            "PostToolUse",
+            None,
+            {
+                "hook_event_name": "PostToolUse",
+                "session_id": "bounded-response",
+                "tool_name": "mcp__reflect__reflect_context",
+                "toolResponse": original,
+            },
+        )
+        data = event.to_lifecycle_data()
+
+        original_text = otel_hook._stringify(original)
+        assert data["tool_response"] == original_text[:64]
+        assert data["tool_response_length"] == len(original_text)
+        assert data["tool_response_sha256"] == hashlib.sha256(original_text.encode()).hexdigest()
+        assert data["tool_response_truncated"] is True
+        assert "toolResponse" not in data
+
+        span = _FakeSpan()
+        otel_hook._set_codex_tool_attrs(span, "PostToolUse", data)
+        assert span.attrs["gen_ai.client.tool.response.length"] == len(original_text)
+        assert span.attrs["gen_ai.client.tool.response.sha256"] == hashlib.sha256(
+            original_text.encode()
+        ).hexdigest()
+
     def test_default_emits_digest_not_content(self, monkeypatch):
         monkeypatch.delenv("IDE_OTEL_CAPTURE_TOOL_INPUT_CONTENT", raising=False)
         span = _FakeSpan()


### PR DESCRIPTION
## What

- choose bootstrap dependencies using the hook runtime's Python ABI and prefer dependencies already owned by the packaged runtime
- bound stale-session finalization to the oldest pending session per interactive invocation
- cap oversized buffered tool responses while retaining their exact length and SHA-256 evidence
- add regression coverage and the `0.14.1` unreleased changelog entry

## Why

The live Stop hook was running under Python 3.12 while prepending compiled dependencies from a bootstrap venv created by Python 3.13. The gRPC exporter could not import `cygrpc`, then the HTTP fallback attempted to use the gRPC endpoint on port 4317. Pending sessions accumulated, and stale-session cleanup eventually pushed Stop past its 30-second timeout. Large buffered tool results could add more state pressure.

## Validation

- `uv run --frozen --with pytest pytest -q` — 432 passed
- `uv run --frozen --with ruff ruff check otel_hook.py tests/test_otel_hook.py`
- isolated live packaged hook smoke test — exporter `healthy_recent`, test queue empty
- recovery test — 25 stale sessions and 2 older session generations exported with 0 failures

## Context

Supports continued dogfooding for o11y-dev/reflect#74.
